### PR TITLE
fix(v7): separate capture vs sender diagnostics and add codec probe

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ mgameStatus()
 Expected:
 
 - `version: "7.0-baseline"`
-- Non-empty `selectedInputLabel` after capture starts
+- Non-empty `captureInputLabel` after capture starts
 - `senderSummary` entries when publishing
 - W3C constraints shown as supported where available
 
@@ -72,6 +72,12 @@ await mgameStats(2000, 20000)
 ```
 
 - Tracks outbound bitrate continuity across 20s.
+
+```js
+await mgameCodecProbe(1200, 12000)
+```
+
+- Captures outbound codec and transport snapshots over time.
 
 ## 5) Manual listening checklist
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ Available console commands in `v7.0-baseline`:
 - `mgameStatus()`
 - `mgameInspect()`
 - `mgameStats(intervalMs, durationMs)`
-- `mgameStereoProbe(sampleMs)`
 - `mgameDropoutProbe(intervalMs, durationMs)`
+- `mgameCodecProbe(intervalMs, durationMs)`
+- `mgameStereoProbe(sampleMs)`
 
 These commands help verify:
 
 - Outbound sender stability
 - Runtime bitrate continuity
+- Runtime codec/transport continuity
 - Stereo integrity vs dual-mono collapse
 - Dropout windows during live publish
 


### PR DESCRIPTION
## Summary
Addresses v7.0 defect tracking issue by improving observability and adding guarded stereo-preservation hint behavior without introducing DSP stages.

## Changes
- Split diagnostics into capture-source vs sender-track identity
- Added synthetic sender warning for WebAudio destination tracks
- Added topology warning when multiple PCs exist but only one active outbound audio sender
- Added per-sender runtime codec/transport snapshots in status/inspect
- Added `mgameCodecProbe(intervalMs, durationMs)` command
- Added guarded sender channels hint (`encodings[0].channels = 2`) only when field exists and differs
- Updated README/INSTALL diagnostics docs

## Validation
```bash
node --check "scripts/current/M-Game Clean Audio v7.0-baseline.user.js"
find scripts/current scripts/legacy -name "*.user.js" -print0 | while IFS= read -r -d '' file; do node --check "$file"; done
bash -n "scripts/tools/analyze_capture_metrics.sh"
SAMPLE_WAV="$(find evidence/audio -maxdepth 1 -name '*.wav' | sort | head -n 1)"
bash "scripts/tools/analyze_capture_metrics.sh" "$SAMPLE_WAV" > /tmp/audio-metrics-issue3.txt
rg -n "input_i|input_tp|mean_volume|max_volume|L-R residual" /tmp/audio-metrics-issue3.txt
```

Closes #3
