### PR TITLE
feat(automation): wire GitHub-Linear sync and Codex dispatch trigger

### DIFF
--- a/.github/workflows/codex-linear-assignment-dispatch.yml
+++ b/.github/workflows/codex-linear-assignment-dispatch.yml
@@ -1,0 +1,82 @@
+name: Codex Linear Assignment Dispatch
+
+on:
+  repository_dispatch:
+    types: [linear_issue_assigned_to_codex]
+  workflow_dispatch:
+    inputs:
+      linear_issue_identifier:
+        description: "Linear issue identifier (example: CE-222)"
+        required: true
+        type: string
+      linear_issue_url:
+        description: "Linear issue URL"
+        required: true
+        type: string
+      github_issue_number:
+        description: "Optional GitHub issue number to notify"
+        required: false
+        type: string
+      title:
+        description: "Optional title when creating a GitHub issue"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Handle assignment dispatch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isRepositoryDispatch = context.eventName === 'repository_dispatch';
+            const payload = isRepositoryDispatch ? (context.payload.client_payload || {}) : {};
+
+            const linearIdentifier = isRepositoryDispatch
+              ? (payload.linearIssueIdentifier || payload.linear_issue_identifier || 'UNKNOWN')
+              : `${{ inputs.linear_issue_identifier }}`;
+            const linearUrl = isRepositoryDispatch
+              ? (payload.linearIssueUrl || payload.linear_issue_url || '')
+              : `${{ inputs.linear_issue_url }}`;
+            const issueNumberRaw = isRepositoryDispatch
+              ? (payload.githubIssueNumber || payload.github_issue_number || '')
+              : `${{ inputs.github_issue_number }}`;
+            const title = isRepositoryDispatch
+              ? (payload.title || `Codex task trigger: ${linearIdentifier}`)
+              : (`${{ inputs.title }}` || `Codex task trigger: ${linearIdentifier}`);
+
+            const issueNumber = Number(issueNumberRaw);
+            const triggerBody = [
+              'Codex run trigger received from Linear assignment.',
+              '',
+              `- Linear issue: ${linearIdentifier}`,
+              linearUrl ? `- URL: ${linearUrl}` : null,
+              '',
+              'This workflow records the trigger event. Execution can be wired to your Codex runner/agent bridge.',
+            ].filter(Boolean).join('\n');
+
+            if (Number.isInteger(issueNumber) && issueNumber > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: triggerBody,
+              });
+              core.notice(`Posted Codex trigger comment on GitHub issue #${issueNumber}`);
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: triggerBody,
+              labels: ['enhancement'],
+            });
+
+            core.notice(`Created GitHub issue #${created.data.number} from Linear assignment trigger.`);

--- a/.github/workflows/sync-github-issue-to-linear.yml
+++ b/.github/workflows/sync-github-issue-to-linear.yml
@@ -1,0 +1,112 @@
+name: Sync GitHub Issue To Linear
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.issue.pull_request }}
+    env:
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+      LINEAR_TEAM_ID: ${{ vars.LINEAR_TEAM_ID }}
+      LINEAR_PROJECT_ID: ${{ vars.LINEAR_PROJECT_ID }}
+    steps:
+      - name: Validate configuration
+        run: |
+          if [ -z "${LINEAR_API_KEY:-}" ]; then
+            echo "Missing required secret: LINEAR_API_KEY"
+            exit 1
+          fi
+          if [ -z "${LINEAR_TEAM_ID:-}" ]; then
+            echo "Missing required repo variable: LINEAR_TEAM_ID"
+            exit 1
+          fi
+          if [ -z "${LINEAR_PROJECT_ID:-}" ]; then
+            echo "Missing required repo variable: LINEAR_PROJECT_ID"
+            exit 1
+          fi
+
+      - name: Create Linear issue
+        id: linear
+        run: |
+          ISSUE_NUMBER="$(jq -r '.issue.number' "$GITHUB_EVENT_PATH")"
+          ISSUE_TITLE="$(jq -r '.issue.title' "$GITHUB_EVENT_PATH")"
+          ISSUE_BODY="$(jq -r '.issue.body // ""' "$GITHUB_EVENT_PATH")"
+          ISSUE_URL="$(jq -r '.issue.html_url' "$GITHUB_EVENT_PATH")"
+
+          LINEAR_TITLE="[GH#${ISSUE_NUMBER}] ${ISSUE_TITLE}"
+          LINEAR_DESCRIPTION="$(cat <<EOF
+GitHub source: ${ISSUE_URL}
+
+Repository: ${GITHUB_REPOSITORY}
+Created from GitHub issue automation.
+
+Original issue body:
+${ISSUE_BODY}
+EOF
+)"
+
+          GRAPHQL_PAYLOAD="$(jq -n \
+            --arg teamId "$LINEAR_TEAM_ID" \
+            --arg projectId "$LINEAR_PROJECT_ID" \
+            --arg title "$LINEAR_TITLE" \
+            --arg description "$LINEAR_DESCRIPTION" \
+            '{
+              query: "mutation($input: IssueCreateInput!){ issueCreate(input:$input){ success issue { id identifier title url } } }",
+              variables: {
+                input: {
+                  teamId: $teamId,
+                  projectId: $projectId,
+                  title: $title,
+                  description: $description
+                }
+              }
+            }'
+          )"
+
+          RESPONSE="$(curl -sS -X POST "https://api.linear.app/graphql" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: ${LINEAR_API_KEY}" \
+            --data-binary "$GRAPHQL_PAYLOAD")"
+
+          SUCCESS="$(printf '%s' "$RESPONSE" | jq -r '.data.issueCreate.success // false')"
+          if [ "$SUCCESS" != "true" ]; then
+            echo "Linear issueCreate failed:"
+            echo "$RESPONSE"
+            exit 1
+          fi
+
+          LINEAR_ID="$(printf '%s' "$RESPONSE" | jq -r '.data.issueCreate.issue.id')"
+          LINEAR_IDENTIFIER="$(printf '%s' "$RESPONSE" | jq -r '.data.issueCreate.issue.identifier')"
+          LINEAR_URL="$(printf '%s' "$RESPONSE" | jq -r '.data.issueCreate.issue.url')"
+
+          echo "linear_id=${LINEAR_ID}" >> "$GITHUB_OUTPUT"
+          echo "linear_identifier=${LINEAR_IDENTIFIER}" >> "$GITHUB_OUTPUT"
+          echo "linear_url=${LINEAR_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on GitHub issue with Linear link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const linearIdentifier = `${{ steps.linear.outputs.linear_identifier }}`;
+            const linearUrl = `${{ steps.linear.outputs.linear_url }}`;
+
+            const body = [
+              'Linear tracking created automatically.',
+              '',
+              `- ${linearIdentifier}: ${linearUrl}`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body,
+            });

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository focuses on one priority for `v7.0`: **capture integrity first**.
   - `scripts/tools/analyze_capture_metrics.sh`
 - Setup, validation, and changelog docs:
   - `docs/`
+  - `docs/setup/linear-github-codex-automation.md`
 - Evidence set (screenshots + WAV):
   - `evidence/`
 
@@ -34,6 +35,10 @@ mgameStatus()
 ```
 
 For full install and live test flow, use `INSTALL.md`.
+
+For Linear/GitHub/Codex automation setup, use:
+
+- `docs/setup/linear-github-codex-automation.md`
 
 ## Runtime Diagnostics
 

--- a/docs/setup/linear-github-codex-automation.md
+++ b/docs/setup/linear-github-codex-automation.md
@@ -1,0 +1,77 @@
+# Linear + GitHub + Codex Automation
+
+This setup enables:
+
+1. GitHub issue opened -> Linear issue created automatically.
+2. Linear assignment event -> GitHub repository dispatch endpoint for Codex trigger handling.
+
+## 1) Configure repository secrets and variables
+
+In GitHub repository settings:
+
+- Secret: `LINEAR_API_KEY`
+  - Your Linear API key (header format is raw key, not `Bearer`).
+- Variable: `LINEAR_TEAM_ID`
+  - Example for this workspace: `a901c542-7bcb-4f89-9731-e753f16ee745` (`CE` team).
+- Variable: `LINEAR_PROJECT_ID`
+  - Project id for `WebRTC Audio Script (M-Game)`.
+
+## 2) GitHub issue to Linear sync
+
+Workflow: `.github/workflows/sync-github-issue-to-linear.yml`
+
+Behavior:
+
+- Trigger: `issues.opened`
+- Creates Linear issue in configured team/project with title prefix:
+  - `[GH#<issue-number>] <github-title>`
+- Posts Linear link back to the GitHub issue as a comment.
+
+## 3) Linear assignment to Codex trigger bridge
+
+Workflow: `.github/workflows/codex-linear-assignment-dispatch.yml`
+
+This workflow accepts:
+
+- `repository_dispatch` event type: `linear_issue_assigned_to_codex`
+- `workflow_dispatch` for manual testing
+
+Expected `repository_dispatch` payload fields:
+
+- `linearIssueIdentifier` (or `linear_issue_identifier`)
+- `linearIssueUrl` (or `linear_issue_url`)
+- optional `githubIssueNumber` (or `github_issue_number`)
+- optional `title`
+
+Behavior:
+
+- If `githubIssueNumber` is provided:
+  - posts a trigger comment on that GitHub issue.
+- Otherwise:
+  - creates a new GitHub issue with a trigger log.
+
+## 4) External trigger example (for Linear webhook bridge)
+
+Use a service (n8n, Zapier, Cloudflare Worker, etc.) that receives Linear webhook events and forwards to GitHub:
+
+```bash
+curl -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer <GH_TOKEN_WITH_REPO_SCOPE>" \
+  https://api.github.com/repos/<owner>/<repo>/dispatches \
+  -d '{
+    "event_type": "linear_issue_assigned_to_codex",
+    "client_payload": {
+      "linearIssueIdentifier": "CE-224",
+      "linearIssueUrl": "https://linear.app/cris-emi/issue/CE-224/...",
+      "githubIssueNumber": 6,
+      "title": "Codex task trigger: CE-224"
+    }
+  }'
+```
+
+## 5) Notes
+
+- This repository now supports agentic tracking and trigger logging.
+- Actual autonomous code execution still depends on your Codex runner/orchestration layer.
+- Keep issue-first policy: every run should trace to a GitHub issue and Linear issue.


### PR DESCRIPTION
## Summary
Implements automation foundation for agentic GitHub + Linear workflow:

1. Auto-sync new GitHub issues to Linear
2. Receive Linear assignment triggers via repository_dispatch

## Changes
- Added `.github/workflows/sync-github-issue-to-linear.yml`
  - Trigger: `issues.opened`
  - Creates Linear issue in configured team/project
  - Posts created Linear link back to GitHub issue
- Added `.github/workflows/codex-linear-assignment-dispatch.yml`
  - Trigger: `repository_dispatch` type `linear_issue_assigned_to_codex`
  - Also supports `workflow_dispatch` test mode
  - Posts trigger comment on mapped GitHub issue (or creates one)
- Added setup guide:
  - `docs/setup/linear-github-codex-automation.md`
- Updated `README.md` to link automation setup doc

## Required repo config
- Secret: `LINEAR_API_KEY`
- Variables: `LINEAR_TEAM_ID`, `LINEAR_PROJECT_ID`

## Notes
- This provides robust event plumbing and issue traceability.
- Full autonomous execution from Linear assignment still depends on your Codex runner/orchestration bridge, which can now target this repository_dispatch endpoint.

Closes #8
