### PR TITLE
fix(process): exempt release PRs from issue-branch gate

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   require-linked-issue:
+    if: ${{ !(github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.ref == 'development') }}
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR body includes closing issue reference

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,10 @@ Every discovered defect or enhancement must be tracked before implementation.
 6. Merge PR to `development`; GitHub closes the linked issue.
 7. Promote `development` to `master` via release PR.
 
+Release PR rule:
+- `development -> master` release PRs are exempt from issue-branch checks in `require-linked-issue`.
+- Issue-first enforcement still applies to normal work PRs (issue branches into `development`).
+
 ## Project priorities
 
 For the current line (`v7.0-baseline`):


### PR DESCRIPTION
## Summary
Prevents false failures on release PRs by exempting `development -> master` from the `require-linked-issue` workflow.

## Why
The issue-first check is correct for normal feature/fix PRs, but release PRs are branch-promotion PRs and do not follow issue branch naming.

## Changes
- `.github/workflows/require-linked-issue.yml`
  - skip job when `base=master` and `head=development`
- `CONTRIBUTING.md`
  - documents release PR exemption explicitly

## Outcome
- Normal issue PRs into `development` remain strictly enforced.
- Release PRs to `master` are not blocked by irrelevant issue-branch checks.

Closes #10
