### PR TITLE
fix(sender): avoid synthetic encodings in setParameters path

### DIFF
--- a/scripts/current/M-Game Clean Audio v7.0-baseline.user.js
+++ b/scripts/current/M-Game Clean Audio v7.0-baseline.user.js
@@ -363,8 +363,11 @@
     }
 
     if (!params) return Promise.resolve(false);
-    if (!params.encodings) params.encodings = [{}];
-    if (!params.encodings.length) params.encodings.push({});
+    if (!params.encodings || !params.encodings.length) {
+      captureSenderSnapshot(sender, pcId);
+      captureSenderRuntimeSnapshot(sender, pcId, 'setParameters-no-encodings');
+      return Promise.resolve(false);
+    }
 
     const encoding0 = params.encodings[0];
     let changed = false;


### PR DESCRIPTION
## Summary
Fixes unresolved review finding on PR #1 / v7 sender diagnostics path.

## Problem
`trySetSenderBitrate` fabricated `params.encodings` entries when missing/empty. That can violate `RTCRtpSender.setParameters` constraints in some implementations and trigger `InvalidModificationError`.

## Fix
- Do not create synthetic encoding entries.
- If sender params have no encodings, bail out safely with diagnostics snapshot.

## Scope
- `scripts/current/M-Game Clean Audio v7.0-baseline.user.js`

## Validation
```bash
node --check "scripts/current/M-Game Clean Audio v7.0-baseline.user.js"
find scripts/current scripts/legacy -name "*.user.js" -print0 | while IFS= read -r -d '' file; do node --check "$file"; done
```

Closes #12
