### PR TITLE
[CE-287] OAuth-first Codex + Linear/GitHub workflow alignment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,12 @@
 
 Describe what changed and why.
 
-## Linked Issue
+## Linear Issue
 
-- Issue: #<id>
-- Closing keyword (required): `Closes #<id>`
+- Linear ID: `CE-<number>`
+- Branch format: `codex/CE-<number>-<slug>`
+- PR title format: `[CE-<number>] <short title>`
+- Optional magic word example: `Closes CE-<number>`
 
 ## Scope
 
@@ -24,14 +26,9 @@ node --check "scripts/current/M-Game Clean Audio v7.0-baseline.user.js"
 bash "scripts/tools/analyze_capture_metrics.sh" "evidence/audio/ScreenRecording_02-20-2026-12-18-00_1.wav"
 ```
 
-## Audio Risk Checklist
+## Checklist
 
-- [ ] Issue was created before implementation started
-- [ ] No new forced DSP stages added to `v7.0-baseline`
-- [ ] No periodic `setParameters()` spam loops introduced
-- [ ] Stereo integrity behavior considered
-- [ ] Dropout behavior considered
-
-## Screenshots / Evidence
-
-Attach console output or sample capture comparisons when relevant.
+- [ ] Branch and PR title include the same Linear ID
+- [ ] Local checks pass (syntax + metrics)
+- [ ] Security or behavior-impacting risks are documented
+- [ ] Screenshot/evidence attached when UI/audio behavior changed

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -4,32 +4,122 @@ on:
   pull_request:
     branches: [development, master]
     types: [opened, edited, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      strict_linear_enforcement:
+        description: "Enable strict Linear enforcement for this manual run"
+        required: false
+        default: true
+        type: boolean
+      head_ref:
+        description: "Head branch to validate (manual runs only)"
+        required: false
+        type: string
+      base_ref:
+        description: "Base branch to validate against (manual runs only)"
+        required: false
+        default: development
+        type: string
+      pr_title:
+        description: "PR title to validate (manual runs only)"
+        required: false
+        type: string
+      pr_body:
+        description: "PR body to validate (manual runs only)"
+        required: false
+        type: string
 
 jobs:
   require-linked-issue:
-    if: ${{ !(github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.ref == 'development') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      EVENT_NAME: ${{ github.event_name }}
+      PR_HEAD_REF: ${{ github.head_ref }}
+      PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+      INPUT_STRICT: ${{ inputs.strict_linear_enforcement }}
+      INPUT_HEAD_REF: ${{ inputs.head_ref }}
+      INPUT_BASE_REF: ${{ inputs.base_ref }}
+      INPUT_PR_TITLE: ${{ inputs.pr_title }}
+      INPUT_PR_BODY: ${{ inputs.pr_body }}
+      REPO_STRICT: ${{ vars.STRICT_LINEAR_ENFORCEMENT }}
     steps:
-      - name: Validate PR body includes closing issue reference
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
+      - name: Validate Linear branch/title conventions
         run: |
-          if ! printf '%s\n' "$PR_BODY" | grep -Eiq '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s*#([0-9]+)'; then
-            echo "PR body must include a closing issue reference, for example: Closes #123"
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            HEAD_REF="$PR_HEAD_REF"
+            BASE_REF="$PR_BASE_REF"
+            PR_TITLE_VALUE="$PR_TITLE"
+            PR_BODY_VALUE="$PR_BODY"
+          else
+            HEAD_REF="$INPUT_HEAD_REF"
+            BASE_REF="$INPUT_BASE_REF"
+            PR_TITLE_VALUE="$INPUT_PR_TITLE"
+            PR_BODY_VALUE="$INPUT_PR_BODY"
+          fi
+
+          STRICT_EFFECTIVE="${INPUT_STRICT:-}"
+          if [ -z "$STRICT_EFFECTIVE" ]; then
+            STRICT_EFFECTIVE="${REPO_STRICT:-true}"
+          fi
+          STRICT_EFFECTIVE="$(printf '%s' "$STRICT_EFFECTIVE" | tr '[:upper:]' '[:lower:]')"
+
+          if [ "$BASE_REF" = "master" ] && [ "$HEAD_REF" = "development" ]; then
+            echo "Release PR exemption applied for development -> master."
+            exit 0
+          fi
+
+          if [ "$STRICT_EFFECTIVE" != "true" ]; then
+            echo "STRICT_LINEAR_ENFORCEMENT is disabled. Skipping Linear branch/title checks."
+            exit 0
+          fi
+
+          if [ -z "$HEAD_REF" ]; then
+            echo "Head branch reference is required for strict validation."
             exit 1
           fi
 
-      - name: Validate branch naming includes issue id
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          if printf '%s\n' "$HEAD_REF" | grep -Eq '^issue/[0-9]+-[a-z0-9._-]+$'; then
-            exit 0
+          if [ -z "$PR_TITLE_VALUE" ]; then
+            echo "PR title is required for strict validation."
+            exit 1
           fi
 
-          if printf '%s\n' "$HEAD_REF" | grep -Eq '^codex/issue-[0-9]+-[a-z0-9._-]+$'; then
-            exit 0
+          if [[ ! "$HEAD_REF" =~ ^codex/(CE-[0-9]+)-[a-z0-9][a-z0-9._-]*$ ]]; then
+            echo "Branch name must match codex/CE-<number>-<slug>."
+            echo "Example: codex/CE-123-fix-stereo-gate"
+            exit 1
+          fi
+          BRANCH_LINEAR_ID="${BASH_REMATCH[1]}"
+
+          if [[ ! "$PR_TITLE_VALUE" =~ ^\[(CE-[0-9]+)\][[:space:]]+.+$ ]]; then
+            echo "PR title must match [CE-<number>] <short title>."
+            echo "Example: [CE-123] Fix stereo gate false positive"
+            exit 1
+          fi
+          TITLE_LINEAR_ID="${BASH_REMATCH[1]}"
+
+          if [ "$BRANCH_LINEAR_ID" != "$TITLE_LINEAR_ID" ]; then
+            echo "Linear issue ID mismatch between branch and PR title."
+            echo "Branch ID: $BRANCH_LINEAR_ID"
+            echo "Title ID:  $TITLE_LINEAR_ID"
+            exit 1
           fi
 
-          echo "Branch name must match issue/<id>-<slug> or codex/issue-<id>-<slug>."
-          exit 1
+          MAGIC_IDS="$(printf '%s\n' "$PR_BODY_VALUE" | grep -Eio '(close[sd]?|fix(e[sd])?|resolve[sd]?)[:[:space:]]+CE-[0-9]+' | grep -Eio 'CE-[0-9]+' | sort -u || true)"
+          if [ -n "$MAGIC_IDS" ]; then
+            while IFS= read -r magic_id; do
+              if [ "$magic_id" != "$BRANCH_LINEAR_ID" ]; then
+                echo "Magic-word Linear ID must match branch/title ID."
+                echo "Expected: $BRANCH_LINEAR_ID"
+                echo "Found in body: $magic_id"
+                exit 1
+              fi
+            done <<< "$MAGIC_IDS"
+          fi
+
+          echo "Linear branch/title policy validated successfully for $BRANCH_LINEAR_ID."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Agent Contract
+
+This repository uses an OAuth-first Codex + Linear + GitHub workflow.
+
+## Workflow Contract
+
+For normal work PRs into `development`:
+
+- Branch format: `codex/CE-<number>-<slug>`
+- PR title format: `[CE-<number>] <short title>`
+- Optional magic words in PR body/commits (`Closes/Fixes/Resolves CE-<number>`) must use the same `CE-<number>` as branch/title.
+
+Release exemption:
+
+- `development -> master` PRs are exempt from branch/title enforcement.
+
+Strict toggle:
+
+- `STRICT_LINEAR_ENFORCEMENT=true` enables strict enforcement in `.github/workflows/require-linked-issue.yml`.
+
+## PR Review Output Contract
+
+When Codex posts PR reviews, use this exact heading order:
+
+1. `## Summary`
+2. `## Critical Issues`
+3. `## Suggestions`
+4. `## Security Notes`
+5. `## Maintainability Notes`
+
+Rules:
+
+- Prefer signal over verbosity.
+- In `## Critical Issues`, include concrete file/line references.
+- If a section has no findings, write `- None.`.
+- Do not propose auto-commit behavior by default.
+
+## Reviewer Source Policy
+
+- Primary AI reviewer source: Codex GitHub app integration (OAuth).
+- Keep CodeRabbit disabled for this repository to reduce noise.
+- Do not add `openai/codex-action` workflows unless the team explicitly adopts API-key-based CI reviews.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,34 +4,28 @@
 
 - `development` is the integration branch.
 - `master` is the stable branch.
-- Open PRs into `development` from issue branches.
+- Normal work PRs target `development`.
 - Release PRs go from `development` to `master`.
 
-## Mandatory issue-first workflow
+## Mandatory Linear-first workflow
 
-Every discovered defect or enhancement must be tracked before implementation.
-
-1. Open (or confirm) a GitHub issue.
-2. Create one issue branch from `development`:
-   - Human branch: `issue/<id>-<slug>`
-   - Agent branch: `codex/issue-<id>-<slug>`
-3. Implement only that issue scope in the branch.
-4. Open PR from issue branch to `development`.
-5. Include a closing keyword in PR body: `Closes #<id>`.
-6. Merge PR to `development`; GitHub closes the linked issue.
-7. Promote `development` to `master` via release PR.
+1. Start from a Linear issue (`CE-<number>`).
+2. Create one branch from `development` using:
+   - `codex/CE-<number>-<slug>`
+3. Open PR to `development` with title:
+   - `[CE-<number>] <short title>`
+4. Optional in PR body or commit message:
+   - `Closes CE-<number>`
+5. Ensure branch ID and PR title ID are the same.
 
 Release PR rule:
-- `development -> master` release PRs are exempt from issue-branch checks in `require-linked-issue`.
-- Issue-first enforcement still applies to normal work PRs (issue branches into `development`).
 
-## Project priorities
+- `development -> master` release PRs are exempt from Linear branch/title checks.
 
-For the current line (`v7.0-baseline`):
+Strict enforcement toggle:
 
-1. Capture integrity first (continuity, level, stereo behavior).
-2. Diagnostics and reproducibility.
-3. Avoid adding DSP complexity unless explicitly gated.
+- Repo variable `STRICT_LINEAR_ENFORCEMENT` controls strict validation.
+- Default behavior is strict (`true`).
 
 ## Local checks before PR
 
@@ -45,8 +39,13 @@ bash "scripts/tools/analyze_capture_metrics.sh" "evidence/audio/ScreenRecording_
 ## PR expectations
 
 - Use the PR template.
-- Link the issue explicitly and include `Closes #<id>`.
-- Confirm the issue existed before implementation.
+- Keep scope tied to one Linear issue.
 - Explain behavior changes and risks.
 - Include diagnostics output for audio-impacting changes.
 - Keep legacy files in `scripts/legacy` unchanged unless there is a specific archival reason.
+
+## AI review policy
+
+- Codex GitHub app integration (OAuth) is the single AI PR reviewer for this repo.
+- Disable CodeRabbit for this repository.
+- Keep review output aligned with `AGENTS.md`.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ For Linear/GitHub/Codex automation setup, use:
 
 - `docs/setup/linear-github-codex-automation.md`
 
+## Workflow
+
+- Branch format: `codex/CE-<number>-<slug>`
+- PR title format: `[CE-<number>] <short title>`
+- Optional magic word in PR body/commit: `Closes CE-<number>`
+- Keep the same `CE-<number>` in branch, title, and any magic-word line.
+- OAuth-based Codex PR review is configured via GitHub app integration (outside CI workflow files).
+
+Example:
+
+```text
+Branch: codex/CE-321-fix-stereo-gate
+Title:  [CE-321] Fix stereo gate false positive
+Body:   Closes CE-321
+```
+
 ## Runtime Diagnostics
 
 Available console commands in `v8.0-transport-first`:

--- a/docs/setup/linear-github-codex-automation.md
+++ b/docs/setup/linear-github-codex-automation.md
@@ -1,59 +1,80 @@
 # Linear + GitHub + Codex Automation
 
-This setup enables:
+This setup provides:
 
 1. GitHub issue opened -> Linear issue created automatically.
 2. Linear assignment event -> GitHub repository dispatch endpoint for Codex trigger handling.
-3. Release events tracked in Linear automatically (`development -> master` PRs and `v*` tags).
+3. Release tracking in Linear for `development -> master` PRs and `v*` tags.
+4. Strict Linear branch/title enforcement for normal work PRs.
+5. One AI reviewer source: Codex GitHub integration (OAuth).
 
 ## 1) Configure repository secrets and variables
 
-In GitHub repository settings:
+In GitHub repository settings, add:
 
 - Secret: `LINEAR_API_KEY`
-  - Your Linear API key (header format is raw key, not `Bearer`).
+  - Linear API key (raw key format, not `Bearer`).
 - Variable: `LINEAR_TEAM_ID`
-  - Example for this workspace: `a901c542-7bcb-4f89-9731-e753f16ee745` (`CE` team).
+  - Team ID for `CE`.
 - Variable: `LINEAR_PROJECT_ID`
-  - Project id for `WebRTC Audio Script (M-Game)`.
+  - Project ID for this repository.
+- Variable: `STRICT_LINEAR_ENFORCEMENT`
+  - Optional toggle for `.github/workflows/require-linked-issue.yml`.
+  - Default/recommended: `true`.
 
-## 2) GitHub issue to Linear sync
+Note:
 
-Workflow: `.github/workflows/sync-github-issue-to-linear.yml`
+- `OPENAI_API_KEY` is not required for this OAuth-first setup.
 
-Behavior:
+## 2) PR linking conventions (Linear-first)
 
-- Trigger: `issues.opened`
-- Creates Linear issue in configured team/project with title prefix:
-  - `[GH#<issue-number>] <github-title>`
-- Posts Linear link back to the GitHub issue as a comment.
+Required for normal work PRs:
 
-## 3) Linear assignment to Codex trigger bridge
+- Branch: `codex/CE-<number>-<slug>`
+- Title: `[CE-<number>] <short title>`
+- Branch ID and title ID must match.
 
-Workflow: `.github/workflows/codex-linear-assignment-dispatch.yml`
+Optional:
 
-This workflow accepts:
+- Magic word in PR body/commit, for example: `Closes CE-123`
+- If used, it must match the same `CE-<number>`.
 
-- `repository_dispatch` event type: `linear_issue_assigned_to_codex`
-- `workflow_dispatch` for manual testing
+Release exemption:
 
-Expected `repository_dispatch` payload fields:
+- `development -> master` release PRs are exempt from branch/title enforcement.
 
-- `linearIssueIdentifier` (or `linear_issue_identifier`)
-- `linearIssueUrl` (or `linear_issue_url`)
-- optional `githubIssueNumber` (or `github_issue_number`)
-- optional `title`
+## 3) Existing Linear sync workflows
 
-Behavior:
+- `.github/workflows/sync-github-issue-to-linear.yml`
+  - Trigger: `issues.opened`
+  - Creates Linear issue and comments link back on GitHub issue.
 
-- If `githubIssueNumber` is provided:
-  - posts a trigger comment on that GitHub issue.
-- Otherwise:
-  - creates a new GitHub issue with a trigger log.
+- `.github/workflows/sync-release-to-linear.yml`
+  - Trigger A: `pull_request` to `master` when `head == development`
+  - Trigger B: `push` tags matching `v*`
+  - Upserts/creates Linear release tracking tickets.
 
-## 4) External trigger example (for Linear webhook bridge)
+## 4) Codex review model (OAuth app-based)
 
-Use a service (n8n, Zapier, Cloudflare Worker, etc.) that receives Linear webhook events and forwards to GitHub:
+Codex PR reviews are provided by the Codex GitHub integration (OAuth), not by a CI workflow.
+
+Required repository-level policy:
+
+- Follow `AGENTS.md` review output contract (structured headings and concise findings).
+
+## 5) Disable duplicate AI reviewers (mandatory)
+
+To keep a single AI reviewer source, disable:
+
+1. CodeRabbit app on this repository.
+
+Keep only:
+
+- Codex GitHub integration review behavior for this repository.
+
+## 6) External trigger example (Linear webhook bridge)
+
+Use a service (n8n, Zapier, Cloudflare Worker, etc.) to forward Linear webhook events to GitHub:
 
 ```bash
 curl -X POST \
@@ -70,26 +91,3 @@ curl -X POST \
     }
   }'
 ```
-
-## 5) Release tracking to Linear
-
-Workflow: `.github/workflows/sync-release-to-linear.yml`
-
-Behavior:
-
-- Trigger A: `pull_request` to `master` when `head == development`
-  - Upserts (create/update) one Linear release ticket.
-  - Keeps the mapping in a PR comment using hidden markers:
-    - `linear-release-ticket-id`
-    - `linear-release-ticket-identifier`
-    - `linear-release-ticket-url`
-  - On each PR sync/edit, updates the same Linear ticket instead of creating duplicates.
-
-- Trigger B: `push` tag matching `v*`
-  - Creates a Linear release tag ticket for the published version tag.
-
-## 6) Notes
-
-- This repository now supports agentic tracking and trigger logging.
-- Actual autonomous code execution still depends on your Codex runner/orchestration layer.
-- Keep issue-first policy: every run should trace to a GitHub issue and Linear issue.


### PR DESCRIPTION
## Summary
- switch repository process to OAuth-first Codex GitHub app review (no API-key workflow)
- keep Linear-first PR enforcement with strict toggle and release exemption
- document single-reviewer policy and structured Codex review contract in AGENTS.md

## Key changes
- add AGENTS.md workflow/review contract
- remove API-key-based codex review workflow artifacts from repo state
- update CONTRIBUTING/README/setup docs for OAuth-first model
- keep PR template aligned with CE branch/title contract

Closes CE-287