### PR TITLE
[CE-298] Finalize v9 strict blocker and private Linear hardening

### DIFF
--- a/.github/workflows/release-merge-create-tag.yml
+++ b/.github/workflows/release-merge-create-tag.yml
@@ -25,8 +25,8 @@ jobs:
       cancel-in-progress: false
     env:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-      LINEAR_TEAM_ID: ${{ vars.LINEAR_TEAM_ID }}
-      LINEAR_PROJECT_ID: ${{ vars.LINEAR_PROJECT_ID }}
+      LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+      LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}
     steps:
       - name: Validate configuration
         run: |
@@ -35,11 +35,11 @@ jobs:
             exit 1
           fi
           if [ -z "${LINEAR_TEAM_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_TEAM_ID"
+            echo "Missing required secret: LINEAR_TEAM_ID"
             exit 1
           fi
           if [ -z "${LINEAR_PROJECT_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_PROJECT_ID"
+            echo "Missing required secret: LINEAR_PROJECT_ID"
             exit 1
           fi
 

--- a/.github/workflows/sync-github-issue-to-linear.yml
+++ b/.github/workflows/sync-github-issue-to-linear.yml
@@ -14,8 +14,8 @@ jobs:
     if: ${{ !github.event.issue.pull_request }}
     env:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-      LINEAR_TEAM_ID: ${{ vars.LINEAR_TEAM_ID }}
-      LINEAR_PROJECT_ID: ${{ vars.LINEAR_PROJECT_ID }}
+      LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+      LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}
     steps:
       - name: Validate configuration
         run: |
@@ -24,11 +24,11 @@ jobs:
             exit 1
           fi
           if [ -z "${LINEAR_TEAM_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_TEAM_ID"
+            echo "Missing required secret: LINEAR_TEAM_ID"
             exit 1
           fi
           if [ -z "${LINEAR_PROJECT_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_PROJECT_ID"
+            echo "Missing required secret: LINEAR_PROJECT_ID"
             exit 1
           fi
 

--- a/.github/workflows/sync-release-pr-to-linear.yml
+++ b/.github/workflows/sync-release-pr-to-linear.yml
@@ -19,8 +19,8 @@ jobs:
       cancel-in-progress: false
     env:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-      LINEAR_TEAM_ID: ${{ vars.LINEAR_TEAM_ID }}
-      LINEAR_PROJECT_ID: ${{ vars.LINEAR_PROJECT_ID }}
+      LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+      LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}
     steps:
       - name: Validate configuration
         run: |
@@ -29,11 +29,11 @@ jobs:
             exit 1
           fi
           if [ -z "${LINEAR_TEAM_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_TEAM_ID"
+            echo "Missing required secret: LINEAR_TEAM_ID"
             exit 1
           fi
           if [ -z "${LINEAR_PROJECT_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_PROJECT_ID"
+            echo "Missing required secret: LINEAR_PROJECT_ID"
             exit 1
           fi
 

--- a/.github/workflows/sync-release-tag-to-linear.yml
+++ b/.github/workflows/sync-release-tag-to-linear.yml
@@ -16,8 +16,8 @@ jobs:
       cancel-in-progress: false
     env:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-      LINEAR_TEAM_ID: ${{ vars.LINEAR_TEAM_ID }}
-      LINEAR_PROJECT_ID: ${{ vars.LINEAR_PROJECT_ID }}
+      LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+      LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}
     steps:
       - name: Validate configuration
         run: |
@@ -26,11 +26,11 @@ jobs:
             exit 1
           fi
           if [ -z "${LINEAR_TEAM_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_TEAM_ID"
+            echo "Missing required secret: LINEAR_TEAM_ID"
             exit 1
           fi
           if [ -z "${LINEAR_PROJECT_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_PROJECT_ID"
+            echo "Missing required secret: LINEAR_PROJECT_ID"
             exit 1
           fi
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,7 @@
+# Agent File Note
+
+Canonical agent instructions for this repository live in:
+
+- `AGENTS.md`
+
+This file exists as a compatibility pointer for tools or contributors that look for `AGENT.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,12 @@ Rules:
 - Archive versioned release snapshots in `scripts/legacy/` (for example `M-Game Clean Audio v8.0-transport-first.user.js`).
 - When this policy changes, update hardcoded references across docs and checks (for example `README.md`, `INSTALL.md`, and `CONTRIBUTING.md`).
 
+## Private Operations Policy
+
+- Do not commit internal management metadata (tokens, team/project IDs, issue URLs, or private workflow mappings).
+- Keep operational identifiers in GitHub Secrets and local runtime configuration only.
+- For this repository, keep Linear operational values private via secrets:
+  - `LINEAR_API_KEY`
+  - `LINEAR_TEAM_ID`
+  - `LINEAR_PROJECT_ID`
+- Keep `STRICT_LINEAR_ENFORCEMENT` configured in repository settings as needed, without storing private IDs in tracked files.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,9 @@
 # Install and Live Test (Atlas + X Spaces)
 
+For the standalone v9 strict WebRTC blocker flow, use:
+
+- `docs/setup/webrtc-strict-blocker-install.md`
+
 ## 1) Install the v8.0 script in Tampermonkey
 
 Use the script file:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Tampermonkey-first toolkit for stabilizing Atlas/X Spaces browser capture with t
 
 This repository is now tracking the `v8.1` release baseline: **music transport integrity first, with gated hardening landed**.
 
+It also includes a separate `v9.0` minimum WebRTC strict-blocker track for selected domains (`chatgpt.com`, `x.com`, `twitter.com`).
+
 - Transport-first baseline (Opus music SDP guard + sender hints)
 - Strict stereo gate diagnostics
 - One-command `v5.2` compatibility fallback profile
@@ -13,13 +15,14 @@ This repository is now tracking the `v8.1` release baseline: **music transport i
 
 - Current script:
   - `scripts/current/M-Game Clean Audio.user.js`
+- Separate strict WebRTC blocker script:
+  - `scripts/current/WebRTC Strict Blocker.user.js`
 - Legacy script archive:
   - `scripts/legacy/`
 - Capture metrics tool:
   - `scripts/tools/analyze_capture_metrics.sh`
 - Setup, validation, and changelog docs:
   - `docs/`
-  - `docs/setup/linear-github-codex-automation.md`
 - Evidence set (screenshots + WAV):
   - `evidence/`
 
@@ -39,9 +42,9 @@ mgameStatus()
 
 For full install and live test flow, use `INSTALL.md`.
 
-For Linear/GitHub/Codex automation setup, use:
+For the standalone strict WebRTC blocker install and test flow, use:
 
-- `docs/setup/linear-github-codex-automation.md`
+- `docs/setup/webrtc-strict-blocker-install.md`
 
 ## Workflow
 
@@ -117,6 +120,10 @@ These findings define the `v8.0` goal: **continuous, stereo-intact, transport-st
 - `v8.1` (released): gated hardening promoted from `development` to `master` via release tag `v8.1`
 
 See `docs/changelog/v7-roadmap.md` for gating criteria.
+
+For v9 strict-blocker release planning, see:
+
+- `docs/changelog/v9-roadmap.md`
 
 ## Project Context Images
 

--- a/docs/analysis/v9-webrtc-disable-research.md
+++ b/docs/analysis/v9-webrtc-disable-research.md
@@ -1,0 +1,35 @@
+# v9 Research: Minimum Effective WebRTC Disable
+
+Research date:
+
+- February 23, 2026
+
+## Sources reviewed
+
+- `https://greasyfork.org/en/scripts/397877-disable-webrtc`
+- `https://greasyfork.org/en/scripts/397877-disable-webrtc/code`
+- `https://chromewebstore.google.com/detail/webrtc-control/fjkmabmdepjfammlpliljpnbhleegehm`
+- `https://developer.chrome.com/docs/extensions/reference/api/privacy`
+- `https://stackoverflow.com/questions/61244780/how-to-remotely-enable-disable-a-tampermonkey-script-for-other-users`
+- `https://raw.githubusercontent.com/egi24/webrtc-control/master/README.md`
+- `https://www.tampermonkey.net/documentation.php`
+
+## Conclusions
+
+1. The GreasyFork script is useful as a baseline but not complete for modern browser behavior.
+2. The baseline snippet misses robust handling expectations for `navigator.mediaDevices.getUserMedia` and defensive override hardening.
+3. A strict userscript can reliably block page-level WebRTC API access on matched domains, but this may break real-time features.
+4. WebRTC Control extension behavior is mainly policy/leak-mitigation oriented and does not represent guaranteed full API-disable semantics for all cases.
+5. Remote enable/disable patterns from Stack Overflow (for example fetching a remote flag) are optional operational controls, not authoritative enforcement over user-local Tampermonkey settings.
+
+## Why v9 uses strict selected-domain blocking
+
+- Goal is deterministic blocking on the target properties where user impact is acceptable.
+- Selected-domain scope avoids global collateral breakage from `*://*/*`.
+- `document-start` is required to reduce early script race windows.
+
+## Out-of-scope for v9
+
+- System-wide network policy management
+- Extension packaging or browser enterprise policy rollout
+- Remote-control backend for toggling user scripts

--- a/docs/changelog/v9-roadmap.md
+++ b/docs/changelog/v9-roadmap.md
@@ -1,0 +1,26 @@
+# v9 Roadmap
+
+## v9.0 (planned)
+
+Minimum effective strict WebRTC blocker release:
+
+- New standalone userscript:
+  - `scripts/current/WebRTC Strict Blocker.user.js`
+- Scope:
+  - `https://chatgpt.com/*`
+  - `https://x.com/*`
+  - `https://twitter.com/*`
+- Strict-only API neutralization:
+  - `RTCPeerConnection` (+ prefixed aliases)
+  - `RTCSessionDescription` (+ prefixed aliases)
+  - legacy `navigator.getUserMedia` aliases
+  - modern `navigator.mediaDevices.getUserMedia`
+
+Release artifacts:
+
+- Install guide:
+  - `docs/setup/webrtc-strict-blocker-install.md`
+- Validation matrix:
+  - `docs/validation/webrtc-v9-strict-matrix.md`
+- Research note:
+  - `docs/analysis/v9-webrtc-disable-research.md`

--- a/docs/setup/linear-github-codex-automation.md
+++ b/docs/setup/linear-github-codex-automation.md
@@ -8,16 +8,38 @@ This setup provides:
 4. Strict Linear branch/title enforcement for normal work PRs.
 5. One AI reviewer source: Codex GitHub integration (OAuth).
 
+## 0) Recommended Codex + Linear MCP configuration
+
+Use the Linear MCP streamable HTTP endpoint with bearer token env var:
+
+```bash
+codex mcp remove linear
+codex mcp add linear --url https://mcp.linear.app/mcp --bearer-token-env-var LINEAR_API_KEY
+codex mcp list
+codex mcp get linear
+```
+
+Expected:
+
+- `url: https://mcp.linear.app/mcp`
+- `bearer_token_env_var: LINEAR_API_KEY`
+- `status: enabled`
+
+Notes:
+
+- Prefer this `/mcp` endpoint for Codex MCP connectivity.
+- Keep the Linear API key in environment/secrets only; do not commit keys to repo files.
+
 ## 1) Configure repository secrets and variables
 
 In GitHub repository settings, add:
 
 - Secret: `LINEAR_API_KEY`
   - Linear API key (raw key format, not `Bearer`).
-- Variable: `LINEAR_TEAM_ID`
-  - Team ID for `CE`.
-- Variable: `LINEAR_PROJECT_ID`
-  - Project ID for this repository.
+- Secret: `LINEAR_TEAM_ID`
+  - Team ID for the target Linear team.
+- Secret: `LINEAR_PROJECT_ID`
+  - Project ID for the target Linear project.
 - Variable: `STRICT_LINEAR_ENFORCEMENT`
   - Optional toggle for `.github/workflows/require-linked-issue.yml`.
   - Default/recommended: `true`.
@@ -92,10 +114,10 @@ curl -X POST \
   -d '{
     "event_type": "linear_issue_assigned_to_codex",
     "client_payload": {
-      "linearIssueIdentifier": "CE-224",
-      "linearIssueUrl": "https://linear.app/cris-emi/issue/CE-224/...",
+      "linearIssueIdentifier": "<ISSUE_IDENTIFIER>",
+      "linearIssueUrl": "https://linear.app/<workspace>/issue/<ISSUE_IDENTIFIER>/...",
       "githubIssueNumber": 6,
-      "title": "Codex task trigger: CE-224"
+      "title": "Codex task trigger: <ISSUE_IDENTIFIER>"
     }
   }'
 ```

--- a/docs/setup/linear-v9-release-plan.md
+++ b/docs/setup/linear-v9-release-plan.md
@@ -1,0 +1,89 @@
+# Linear Configuration: v9 Strict WebRTC Blocker Release
+
+Team:
+
+- `CE`
+
+Labels:
+
+- `webrtc`
+- `tampermonkey`
+- `release-v9`
+- `privacy`
+
+Target window:
+
+- Start: February 24, 2026
+- End: March 10, 2026
+
+## Milestone / release bucket
+
+- Issue key: `CE-NEW-1` (placeholder)
+- Title: `[CE-NEW-1] v9.0 milestone: minimum WebRTC disable (selected domains)`
+- Scope:
+  - Release tracking
+  - Child issue linkage
+  - Go/no-go checklist
+  - Release notes draft
+
+## Work tickets
+
+### CE-NEW-2
+
+- Title: `[CE-NEW-2] Implement strict WebRTC blocker userscript for Atlas + X`
+- Linear issue: `<to be created>`
+- Priority: `High`
+- Scope:
+  - Add standalone userscript artifact
+  - Strict-only behavior
+  - Selected domain matches (`chatgpt.com`, `x.com`, `twitter.com`)
+- Acceptance:
+  - On target domains, blocked APIs are not usable
+  - Script loads at `document-start`
+  - No changes to `scripts/current/M-Game Clean Audio.user.js`
+
+### CE-NEW-3
+
+- Title: `[CE-NEW-3] Add validation matrix for strict blocking behavior`
+- Linear issue: `<to be created>`
+- Priority: `High`
+- Scope:
+  - Create reproducible validation matrix
+  - Include one non-target domain control test
+- Acceptance:
+  - Matrix completed
+  - Regressions documented
+
+### CE-NEW-4
+
+- Title: `[CE-NEW-4] Documentation for install, scope, and known breakage`
+- Linear issue: `<to be created>`
+- Priority: `Medium`
+- Scope:
+  - Install flow
+  - Limitations and rollback
+  - Known breakage warning
+- Acceptance:
+  - Clear docs published for install/use/rollback
+
+### CE-NEW-5
+
+- Title: `[CE-NEW-5] Research note: userscript strict block vs WebRTC Control extension`
+- Linear issue: `<to be created>`
+- Priority: `Medium`
+- Scope:
+  - Evidence-backed comparison
+  - Recommendation boundaries
+- Acceptance:
+  - Final note published in `docs/analysis/`
+
+## Workflow notes
+
+- Branch format: `codex/CE-<number>-<slug>`
+- PR title format: `[CE-<number>] <short title>`
+- Optional magic words must use the same `CE-<number>`
+- Normal work targets `development`
+
+## Status
+
+Use private Linear workspace references (not committed in repository files) to map these placeholders to real issue IDs and URLs.

--- a/docs/setup/webrtc-strict-blocker-install.md
+++ b/docs/setup/webrtc-strict-blocker-install.md
@@ -1,0 +1,82 @@
+# Install and Validate: v9 WebRTC Strict Blocker
+
+This guide is for the standalone userscript:
+
+- `scripts/current/WebRTC Strict Blocker.user.js`
+
+Scope in v9:
+
+- `https://chatgpt.com/*`
+- `https://x.com/*`
+- `https://twitter.com/*`
+
+Behavior in v9:
+
+- Strict-only (no runtime toggle)
+- Blocks WebRTC constructors and `getUserMedia` entry points
+
+## 1) Install in Tampermonkey
+
+1. Open Tampermonkey dashboard.
+2. Click `Utilities` -> `Import from file`.
+3. Select:
+   - `scripts/current/WebRTC Strict Blocker.user.js`
+4. Save and verify the script is enabled.
+
+## 2) Confirm the script is loaded
+
+Open DevTools on a matched domain and run:
+
+```js
+webrtcBlockerStatus()
+```
+
+Expected:
+
+- `installed: true`
+- `version: "9.0"`
+- `blockedTargets` includes constructor and `getUserMedia` entries
+
+## 3) Quick behavior checks on matched domains
+
+Run:
+
+```js
+typeof RTCPeerConnection
+```
+
+Then:
+
+```js
+navigator.mediaDevices.getUserMedia({ audio: true }).catch((e) => e.message)
+```
+
+Expected:
+
+- Constructor use is blocked (not usable for WebRTC session setup)
+- `getUserMedia` rejects with the blocker reason
+
+## 4) Non-target control test
+
+Open a non-matched domain and run:
+
+```js
+typeof RTCPeerConnection
+```
+
+Expected:
+
+- This script should not affect non-matched domains.
+
+## 5) Rollback
+
+If a target site requires WebRTC and breaks:
+
+1. Disable `WebRTC Strict Blocker (Atlas + X)` in Tampermonkey.
+2. Reload the site tab.
+3. Re-run checks to confirm WebRTC APIs are restored.
+
+## Known limitations
+
+- Sites that depend on real-time calling, screen share, or conferencing may fail while the script is enabled.
+- This userscript blocks in-page API access; it is not a system-wide browser network policy control.

--- a/docs/validation/webrtc-v9-strict-matrix.md
+++ b/docs/validation/webrtc-v9-strict-matrix.md
@@ -1,0 +1,39 @@
+# v9 Strict Blocker Validation Matrix
+
+Release target window:
+
+- February 24, 2026 to March 10, 2026
+
+Script under test:
+
+- `scripts/current/WebRTC Strict Blocker.user.js`
+
+## Test matrix
+
+| ID | Scenario | Domain | Steps | Expected | Status |
+|---|---|---|---|---|---|
+| V9-01 | Constructor block | `chatgpt.com` | Load page, run `typeof RTCPeerConnection`, attempt constructor usage | WebRTC constructor is not usable | Pending |
+| V9-02 | Modern API block | `chatgpt.com` | Run `navigator.mediaDevices.getUserMedia({ audio: true })` | Promise rejects with blocker reason | Pending |
+| V9-03 | Legacy API block | `chatgpt.com` | Run `navigator.getUserMedia` path if present | Legacy entry points are blocked | Pending |
+| V9-04 | Constructor block | `x.com` | Repeat V9-01 on `x.com` | Same strict blocking behavior | Pending |
+| V9-05 | Modern API block | `x.com` | Repeat V9-02 on `x.com` | Same strict blocking behavior | Pending |
+| V9-06 | Constructor block | `twitter.com` | Repeat V9-01 on `twitter.com` | Same strict blocking behavior | Pending |
+| V9-07 | Modern API block | `twitter.com` | Repeat V9-02 on `twitter.com` | Same strict blocking behavior | Pending |
+| V9-08 | Non-target control | Any non-matched domain | Run WebRTC checks outside match scope | Script has no effect | Pending |
+| V9-09 | Race timing | Matched domains | Hard reload and run checks immediately | Blocking is active from `document-start` | Pending |
+| V9-10 | Compatibility check | `chatgpt.com` / `x.com` | Validate existing M-Game script path remains untouched | No regression in `scripts/current/M-Game Clean Audio.user.js` path | Pending |
+
+## Run notes template
+
+Use this format per run:
+
+```text
+Date:
+Browser:
+Tampermonkey version:
+Domain:
+Scenario IDs:
+Observed result:
+Pass/Fail:
+Notes:
+```

--- a/scripts/current/WebRTC Strict Blocker.user.js
+++ b/scripts/current/WebRTC Strict Blocker.user.js
@@ -1,0 +1,155 @@
+// ==UserScript==
+// @name         WebRTC Strict Blocker (Atlas + X)
+// @namespace    http://tampermonkey.net/
+// @version      9.0
+// @description  Strictly disables WebRTC constructors and getUserMedia on selected domains.
+// @author       Cris Sarmiento
+// @match        https://chatgpt.com/*
+// @match        https://x.com/*
+// @match        https://twitter.com/*
+// @grant        none
+// @run-at       document-start
+// ==/UserScript==
+
+(function () {
+  'use strict';
+
+  const VERSION = '9.0';
+  const TAG = '[WebRTC Blocker v9.0]';
+  const BLOCK_REASON = 'WebRTC is disabled by the WebRTC Strict Blocker userscript.';
+
+  if (window.__webrtcBlockerV9 && window.__webrtcBlockerV9.installed) {
+    console.info(TAG, 'Already installed. Skipping duplicate injection.');
+    return;
+  }
+
+  const state = {
+    installed: true,
+    version: VERSION,
+    installedAt: new Date().toISOString(),
+    blockedTargets: [],
+    failedTargets: [],
+  };
+
+  window.__webrtcBlockerV9 = state;
+
+  function cloneState() {
+    return {
+      installed: state.installed,
+      version: state.version,
+      installedAt: state.installedAt,
+      blockedTargets: state.blockedTargets.slice(),
+      failedTargets: state.failedTargets.slice(),
+    };
+  }
+
+  window.webrtcBlockerStatus = function webrtcBlockerStatus() {
+    return cloneState();
+  };
+
+  function recordBlocked(name) {
+    state.blockedTargets.push(name);
+  }
+
+  function recordFailure(name, error) {
+    state.failedTargets.push({
+      target: name,
+      reason: String(error && error.message ? error.message : error),
+    });
+  }
+
+  function defineBlocked(target, key, value, name) {
+    if (!target) return false;
+
+    try {
+      Object.defineProperty(target, key, {
+        configurable: true,
+        enumerable: false,
+        writable: false,
+        value,
+      });
+      recordBlocked(name);
+      return true;
+    } catch (defineError) {
+      try {
+        target[key] = value;
+        recordBlocked(name);
+        return true;
+      } catch (assignError) {
+        recordFailure(name, assignError || defineError);
+        return false;
+      }
+    }
+  }
+
+  function blockedConstructor() {
+    throw new Error(BLOCK_REASON);
+  }
+
+  function blockedLegacyGetUserMedia(constraints, onSuccess, onError) {
+    const error = new Error(BLOCK_REASON);
+    if (typeof onError === 'function') {
+      try {
+        onError(error);
+      } catch {
+        // no-op
+      }
+    }
+    return Promise.reject(error);
+  }
+
+  function blockedModernGetUserMedia() {
+    return Promise.reject(new Error(BLOCK_REASON));
+  }
+
+  const constructorTargets = [
+    ['RTCPeerConnection', window],
+    ['mozRTCPeerConnection', window],
+    ['webkitRTCPeerConnection', window],
+    ['RTCSessionDescription', window],
+    ['mozRTCSessionDescription', window],
+    ['webkitRTCSessionDescription', window],
+  ];
+
+  constructorTargets.forEach(([name, target]) => {
+    defineBlocked(target, name, blockedConstructor, `window.${name}`);
+  });
+
+  const legacyNavigatorTargets = [
+    'getUserMedia',
+    'mozGetUserMedia',
+    'webkitGetUserMedia',
+  ];
+
+  legacyNavigatorTargets.forEach((name) => {
+    defineBlocked(
+      navigator,
+      name,
+      blockedLegacyGetUserMedia,
+      `navigator.${name}`
+    );
+  });
+
+  if (navigator.mediaDevices) {
+    const blockedDirect = defineBlocked(
+      navigator.mediaDevices,
+      'getUserMedia',
+      blockedModernGetUserMedia,
+      'navigator.mediaDevices.getUserMedia'
+    );
+
+    if (!blockedDirect) {
+      const mediaDevicesPrototype = Object.getPrototypeOf(navigator.mediaDevices);
+      defineBlocked(
+        mediaDevicesPrototype,
+        'getUserMedia',
+        blockedModernGetUserMedia,
+        'MediaDevices.prototype.getUserMedia'
+      );
+    }
+  } else {
+    recordFailure('navigator.mediaDevices', 'mediaDevices is unavailable.');
+  }
+
+  console.info(TAG, 'Strict blocking active.', cloneState());
+})();


### PR DESCRIPTION
Closes CE-298

## Summary
- add standalone v9 strict WebRTC blocker userscript and supporting docs
- add v9 validation/research/roadmap artifacts
- harden Linear automation by moving LINEAR_TEAM_ID and LINEAR_PROJECT_ID usage to GitHub secrets
- scrub private management metadata from tracked docs and add private-operations policy

## Validation
- node --check scripts/current/WebRTC Strict Blocker.user.js
- node --check scripts/current/M-Game Clean Audio.user.js
- repo scan confirms no committed private Linear IDs/issue URLs