### PR TITLE
[CE-298] Finalize v9 strict blocker release artifacts and harden Linear secret handling

### DIFF
--- a/.github/workflows/release-merge-create-tag.yml
+++ b/.github/workflows/release-merge-create-tag.yml
@@ -25,8 +25,8 @@ jobs:
       cancel-in-progress: false
     env:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-      LINEAR_TEAM_ID: ${{ vars.LINEAR_TEAM_ID }}
-      LINEAR_PROJECT_ID: ${{ vars.LINEAR_PROJECT_ID }}
+      LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+      LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}
     steps:
       - name: Validate configuration
         run: |
@@ -35,11 +35,11 @@ jobs:
             exit 1
           fi
           if [ -z "${LINEAR_TEAM_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_TEAM_ID"
+            echo "Missing required secret: LINEAR_TEAM_ID"
             exit 1
           fi
           if [ -z "${LINEAR_PROJECT_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_PROJECT_ID"
+            echo "Missing required secret: LINEAR_PROJECT_ID"
             exit 1
           fi
 

--- a/.github/workflows/sync-github-issue-to-linear.yml
+++ b/.github/workflows/sync-github-issue-to-linear.yml
@@ -14,8 +14,8 @@ jobs:
     if: ${{ !github.event.issue.pull_request }}
     env:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-      LINEAR_TEAM_ID: ${{ vars.LINEAR_TEAM_ID }}
-      LINEAR_PROJECT_ID: ${{ vars.LINEAR_PROJECT_ID }}
+      LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+      LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}
     steps:
       - name: Validate configuration
         run: |
@@ -24,11 +24,11 @@ jobs:
             exit 1
           fi
           if [ -z "${LINEAR_TEAM_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_TEAM_ID"
+            echo "Missing required secret: LINEAR_TEAM_ID"
             exit 1
           fi
           if [ -z "${LINEAR_PROJECT_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_PROJECT_ID"
+            echo "Missing required secret: LINEAR_PROJECT_ID"
             exit 1
           fi
 
@@ -41,16 +41,14 @@ jobs:
           ISSUE_URL="$(jq -r '.issue.html_url' "$GITHUB_EVENT_PATH")"
 
           LINEAR_TITLE="[GH#${ISSUE_NUMBER}] ${ISSUE_TITLE}"
-          LINEAR_DESCRIPTION="$(cat <<EOF
-GitHub source: ${ISSUE_URL}
-
-Repository: ${GITHUB_REPOSITORY}
-Created from GitHub issue automation.
-
-Original issue body:
-${ISSUE_BODY}
-EOF
-)"
+          LINEAR_DESCRIPTION="$(printf '%s\n' \
+            "GitHub source: ${ISSUE_URL}" \
+            "" \
+            "Repository: ${GITHUB_REPOSITORY}" \
+            "Created from GitHub issue automation." \
+            "" \
+            "Original issue body:" \
+            "${ISSUE_BODY}")"
 
           GRAPHQL_PAYLOAD="$(jq -n \
             --arg teamId "$LINEAR_TEAM_ID" \

--- a/.github/workflows/sync-release-pr-to-linear.yml
+++ b/.github/workflows/sync-release-pr-to-linear.yml
@@ -19,8 +19,8 @@ jobs:
       cancel-in-progress: false
     env:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-      LINEAR_TEAM_ID: ${{ vars.LINEAR_TEAM_ID }}
-      LINEAR_PROJECT_ID: ${{ vars.LINEAR_PROJECT_ID }}
+      LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+      LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}
     steps:
       - name: Validate configuration
         run: |
@@ -29,11 +29,11 @@ jobs:
             exit 1
           fi
           if [ -z "${LINEAR_TEAM_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_TEAM_ID"
+            echo "Missing required secret: LINEAR_TEAM_ID"
             exit 1
           fi
           if [ -z "${LINEAR_PROJECT_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_PROJECT_ID"
+            echo "Missing required secret: LINEAR_PROJECT_ID"
             exit 1
           fi
 

--- a/.github/workflows/sync-release-tag-to-linear.yml
+++ b/.github/workflows/sync-release-tag-to-linear.yml
@@ -16,8 +16,8 @@ jobs:
       cancel-in-progress: false
     env:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-      LINEAR_TEAM_ID: ${{ vars.LINEAR_TEAM_ID }}
-      LINEAR_PROJECT_ID: ${{ vars.LINEAR_PROJECT_ID }}
+      LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+      LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}
     steps:
       - name: Validate configuration
         run: |
@@ -26,11 +26,11 @@ jobs:
             exit 1
           fi
           if [ -z "${LINEAR_TEAM_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_TEAM_ID"
+            echo "Missing required secret: LINEAR_TEAM_ID"
             exit 1
           fi
           if [ -z "${LINEAR_PROJECT_ID:-}" ]; then
-            echo "Missing required repo variable: LINEAR_PROJECT_ID"
+            echo "Missing required secret: LINEAR_PROJECT_ID"
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,12 @@ Strict toggle:
 
 - `STRICT_LINEAR_ENFORCEMENT=true` enables strict enforcement in `.github/workflows/require-linked-issue.yml`.
 
+## Private Operations Policy
+
+- Treat `LINEAR_API_KEY`, `LINEAR_TEAM_ID`, and `LINEAR_PROJECT_ID` as secrets only.
+- Never commit raw Linear team/project IDs, private management identifiers, or internal-only issue URLs to tracked files.
+- Use sanitized placeholders (for example: `<LINEAR_ISSUE_URL>`) in docs, examples, and logs.
+
 ## PR Review Output Contract
 
 When Codex posts PR reviews, use this exact heading order:

--- a/README.md
+++ b/README.md
@@ -2,17 +2,16 @@
 
 Tampermonkey-first toolkit for stabilizing Atlas/X Spaces browser capture with the RODE M-Game RGB Dual.
 
-This repository currently focuses on one priority for `v8.0`: **music transport integrity first**.
+This repository tracks two active tracks:
 
-- Transport-first baseline (Opus music SDP guard + sender hints)
-- Strict stereo gate diagnostics
-- One-command `v5.2` compatibility fallback profile
-- Reproducible audio evidence workflow
+- `v8.x` transport-first music stability for Atlas/X Spaces
+- `v9.0` standalone strict WebRTC processing blocker
 
 ## What Is Included
 
-- Current script:
+- Current scripts:
   - `scripts/current/M-Game Clean Audio v7.0-baseline.user.js`
+  - `scripts/current/Disable WebRTC Audio Processing v9.0-strict.user.js`
 - Legacy script archive:
   - `scripts/legacy/`
 - Capture metrics tool:
@@ -25,9 +24,11 @@ This repository currently focuses on one priority for `v8.0`: **music transport 
 
 ## Quick Start
 
-1. Import `scripts/current/M-Game Clean Audio v7.0-baseline.user.js` into Tampermonkey.
-2. Enable the script and reload Atlas/X tab.
-3. In Atlas, select mic input:
+1. Import one of the current scripts into Tampermonkey:
+   - `scripts/current/M-Game Clean Audio v7.0-baseline.user.js` (transport-first Atlas/X path)
+   - `scripts/current/Disable WebRTC Audio Processing v9.0-strict.user.js` (standalone strict blocker)
+2. Enable the script and reload the target tab.
+3. For Atlas transport testing, select mic input:
    - `Default - M-Game RGB Dual Stream`
 4. Open DevTools Console and verify:
 
@@ -36,6 +37,10 @@ mgameStatus()
 ```
 
 For full install and live test flow, use `INSTALL.md`.
+
+For v9 standalone blocker validation, use:
+
+- `docs/validation/v9-strict-blocker-validation.md`
 
 For Linear/GitHub/Codex automation setup, use:
 

--- a/docs/analysis/v9-strict-blocker-research.md
+++ b/docs/analysis/v9-strict-blocker-research.md
@@ -1,0 +1,23 @@
+# v9 Strict Blocker Research Notes
+
+## Goal
+
+Create a standalone userscript that strictly disables WebRTC voice processing without depending on transport, SDP, or Atlas/X-specific runtime hooks.
+
+## Research Summary
+
+- Modern Chromium paths can re-introduce browser processing when sites call `MediaStreamTrack.applyConstraints()` after initial capture.
+- Some sites still pass legacy `goog*` flags; preserving explicit `false` values for those flags improves compatibility with legacy wrappers.
+- `voiceIsolation` is optional and browser-dependent, so v9 applies it only when supported.
+
+## Design Decisions
+
+1. Intercept both `navigator.mediaDevices.getUserMedia()` and `MediaStreamTrack.prototype.applyConstraints()`.
+2. Normalize `audio: true` requests to explicit objects before hardening flags.
+3. Avoid `exact` constraint usage to reduce overconstraint failures.
+4. Provide a tiny runtime status function (`webrtcBlockerV9Status()`) for operator verification.
+
+## Out of Scope
+
+- Transport diagnostics and Opus SDP mutation from v8 transport-first builds.
+- Atlas-only routing assumptions.

--- a/docs/changelog/v9-strict-blocker-release.md
+++ b/docs/changelog/v9-strict-blocker-release.md
@@ -1,0 +1,15 @@
+# v9 Strict Blocker Release Artifacts
+
+## Added
+
+- Standalone strict WebRTC blocker userscript:
+  - `scripts/current/Disable WebRTC Audio Processing v9.0-strict.user.js`
+- Research notes:
+  - `docs/analysis/v9-strict-blocker-research.md`
+- Validation checklist:
+  - `docs/validation/v9-strict-blocker-validation.md`
+
+## Security/Operations Hardening
+
+- Linear team/project workflow configuration now uses repository secrets instead of variables.
+- Sanitized setup documentation examples to avoid exposing internal issue URLs.

--- a/docs/setup/linear-github-codex-automation.md
+++ b/docs/setup/linear-github-codex-automation.md
@@ -8,16 +8,16 @@ This setup provides:
 4. Strict Linear branch/title enforcement for normal work PRs.
 5. One AI reviewer source: Codex GitHub integration (OAuth).
 
-## 1) Configure repository secrets and variables
+## 1) Configure repository secrets
 
 In GitHub repository settings, add:
 
 - Secret: `LINEAR_API_KEY`
   - Linear API key (raw key format, not `Bearer`).
-- Variable: `LINEAR_TEAM_ID`
-  - Team ID for `CE`.
-- Variable: `LINEAR_PROJECT_ID`
-  - Project ID for this repository.
+- Secret: `LINEAR_TEAM_ID`
+  - Team ID for `CE` (kept private).
+- Secret: `LINEAR_PROJECT_ID`
+  - Project ID for this repository (kept private).
 - Variable: `STRICT_LINEAR_ENFORCEMENT`
   - Optional toggle for `.github/workflows/require-linked-issue.yml`.
   - Default/recommended: `true`.
@@ -93,7 +93,7 @@ curl -X POST \
     "event_type": "linear_issue_assigned_to_codex",
     "client_payload": {
       "linearIssueIdentifier": "CE-224",
-      "linearIssueUrl": "https://linear.app/cris-emi/issue/CE-224/...",
+      "linearIssueUrl": "<LINEAR_ISSUE_URL>",
       "githubIssueNumber": 6,
       "title": "Codex task trigger: CE-224"
     }

--- a/docs/validation/v9-strict-blocker-validation.md
+++ b/docs/validation/v9-strict-blocker-validation.md
@@ -1,0 +1,19 @@
+# v9 Strict Blocker Validation
+
+## Environment
+
+- Browser: Chromium-family browser with Tampermonkey.
+- Script under test: `scripts/current/Disable WebRTC Audio Processing v9.0-strict.user.js`.
+
+## Manual Validation Checklist
+
+1. Load a site that requests microphone access.
+2. Confirm console log includes `[WebRTC Blocker v9.0] Installed strict blocker globally.`
+3. Trigger microphone capture and verify `getUserMedia intercepted` log appears.
+4. Trigger any in-app mic setting changes and verify `applyConstraints intercepted for audio track` appears.
+5. Run `webrtcBlockerV9Status()` and confirm all audio processing flags are `false` (or `voiceIsolation: "unsupported"`).
+
+## Expected Outcome
+
+- Browser-level AGC/NS/EC flags remain disabled across both initial capture and later constraint updates.
+- Script functions independently from Atlas/X transport tuning logic.

--- a/scripts/current/Disable WebRTC Audio Processing v9.0-strict.user.js
+++ b/scripts/current/Disable WebRTC Audio Processing v9.0-strict.user.js
@@ -1,0 +1,111 @@
+// ==UserScript==
+// @name         Disable WebRTC Audio Processing v9.0 Strict Blocker
+// @namespace    http://tampermonkey.net/
+// @version      9.0
+// @description  Standalone strict blocker that disables browser-side WebRTC voice processing in getUserMedia/applyConstraints paths.
+// @author       Cris Sarmiento
+// @match        *://*/*
+// @grant        none
+// @run-at       document-start
+// @noframes
+// ==/UserScript==
+
+(function () {
+  'use strict';
+
+  const TAG = '[WebRTC Blocker v9.0]';
+  const W3C_AUDIO_FLAGS = {
+    autoGainControl: false,
+    echoCancellation: false,
+    noiseSuppression: false,
+  };
+  const GOOG_AUDIO_FLAGS = {
+    googAutoGainControl: false,
+    googAutoGainControl2: false,
+    googEchoCancellation: false,
+    googExperimentalAutoGainControl: false,
+    googExperimentalEchoCancellation: false,
+    googExperimentalNoiseSuppression: false,
+    googHighpassFilter: false,
+    googNoiseSuppression: false,
+    googNoiseSuppression2: false,
+    googNoiseReduction: false,
+    googTypingNoiseDetection: false,
+  };
+
+  const log = (...args) => console.log(TAG, ...args);
+  const warn = (...args) => console.warn(TAG, ...args);
+
+  if (!navigator.mediaDevices || typeof navigator.mediaDevices.getUserMedia !== 'function') {
+    warn('navigator.mediaDevices.getUserMedia is unavailable; strict blocker not installed.');
+    return;
+  }
+
+  const safeClone = (value) => {
+    try {
+      return structuredClone(value);
+    } catch {
+      try {
+        return JSON.parse(JSON.stringify(value));
+      } catch {
+        return value;
+      }
+    }
+  };
+
+  const supports = (() => {
+    try {
+      return navigator.mediaDevices.getSupportedConstraints?.() || {};
+    } catch {
+      return {};
+    }
+  })();
+
+  function normalizeAudioRequest(audio) {
+    if (audio === true) return {};
+    if (audio === false || audio == null) return null;
+    if (typeof audio !== 'object') return {};
+    return audio;
+  }
+
+  function applyStrictAudioFlags(audioConfig) {
+    const next = { ...audioConfig, ...W3C_AUDIO_FLAGS, ...GOOG_AUDIO_FLAGS };
+    if (supports.voiceIsolation) next.voiceIsolation = false;
+    return next;
+  }
+
+  function hardenConstraints(constraints) {
+    const next = safeClone(constraints) || {};
+    const audio = normalizeAudioRequest(next.audio);
+    if (audio === null) return next;
+    next.audio = applyStrictAudioFlags(audio);
+    return next;
+  }
+
+  const originalGetUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+  navigator.mediaDevices.getUserMedia = function patchedGetUserMedia(constraints) {
+    const hardened = hardenConstraints(constraints);
+    log('getUserMedia intercepted.', { requested: constraints, hardened });
+    return originalGetUserMedia(hardened);
+  };
+
+  const originalApplyConstraints = MediaStreamTrack.prototype.applyConstraints;
+  MediaStreamTrack.prototype.applyConstraints = function patchedApplyConstraints(constraints) {
+    if (this?.kind !== 'audio') {
+      return originalApplyConstraints.call(this, constraints);
+    }
+
+    const hardened = applyStrictAudioFlags(safeClone(constraints) || {});
+    log('applyConstraints intercepted for audio track.', { requested: constraints, hardened });
+    return originalApplyConstraints.call(this, hardened);
+  };
+
+  window.webrtcBlockerV9Status = () => ({
+    installed: true,
+    version: '9.0',
+    tag: TAG,
+    audioFlags: { ...W3C_AUDIO_FLAGS, ...GOOG_AUDIO_FLAGS, voiceIsolation: supports.voiceIsolation ? false : 'unsupported' },
+  });
+
+  log('Installed strict blocker globally.');
+})();


### PR DESCRIPTION
### Motivation
- Provide a standalone `v9.0` userscript to strictly disable browser-side WebRTC voice processing across both initial capture and later constraint updates.
- Remove private Linear identifiers from tracked files and ensure workflow automation reads sensitive IDs from secrets instead of repo variables.
- Add documentation and validation artifacts to support release, operator verification, and research findings for the v9 blocker.

### Description
- Add `scripts/current/Disable WebRTC Audio Processing v9.0-strict.user.js`, which intercepts `navigator.mediaDevices.getUserMedia()` and `MediaStreamTrack.prototype.applyConstraints()` and exposes `webrtcBlockerV9Status()` for runtime verification.
- Add v9 supporting docs: `docs/analysis/v9-strict-blocker-research.md`, `docs/validation/v9-strict-blocker-validation.md`, and `docs/changelog/v9-strict-blocker-release.md`.
- Update docs to reference the v9 track and sanitize internal Linear URLs, and add a Private Operations Policy to `AGENTS.md` to avoid committing private IDs/URLs.
- Migrate Linear workflow usage of `LINEAR_TEAM_ID` and `LINEAR_PROJECT_ID` from repo variables to repository secrets and update validation messages in `.github/workflows/*` files, and fix a multi-line string construction in the GitHub issue sync workflow so YAML parses cleanly.

### Testing
- Ran `node --check "scripts/current/Disable WebRTC Audio Processing v9.0-strict.user.js"` and it succeeded.
- Ran `git diff --check` to validate no whitespace or diff issues and it succeeded.
- Parsed workflow YAMLs with Ruby (`YAML.load_file`) to validate syntax and it succeeded.
- Verified there are no tracked internal Linear URLs by running the repository search for `https://linear.app` and related patterns and found none.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d03b53440832a9277fb90af84b538)