### PR TITLE
[CRIS-118] Automate draft GitHub release creation for release merges

### DIFF
--- a/.github/workflows/release-merge-create-tag.yml
+++ b/.github/workflows/release-merge-create-tag.yml
@@ -111,6 +111,7 @@ jobs:
 
           TAG_NAME="$VERSION"
           TAG_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG_NAME}"
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG_NAME}"
 
           LINEAR_TITLE="[Release Tag ${TAG_NAME}] ${GITHUB_REPOSITORY}"
           LINEAR_DESCRIPTION="$(printf '%s\n' \
@@ -129,6 +130,7 @@ jobs:
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
           echo "tag_url=${TAG_URL}" >> "$GITHUB_OUTPUT"
+          echo "release_url=${RELEASE_URL}" >> "$GITHUB_OUTPUT"
           echo "merge_sha=${MERGE_SHA}" >> "$GITHUB_OUTPUT"
           echo "linear_title=${LINEAR_TITLE}" >> "$GITHUB_OUTPUT"
           DELIMITER="EOF_$(date +%s)_$RANDOM"
@@ -343,6 +345,48 @@ jobs:
           echo "linear_identifier=${LINEAR_IDENTIFIER}" >> "$GITHUB_OUTPUT"
           echo "linear_url=${LINEAR_URL}" >> "$GITHUB_OUTPUT"
 
+      - name: Create draft GitHub release if missing
+        id: release
+        uses: actions/github-script@v7
+        env:
+          TAG_NAME: ${{ steps.context.outputs.tag_name }}
+          MERGE_SHA: ${{ steps.context.outputs.merge_sha }}
+        with:
+          script: |
+            const tagName = process.env.TAG_NAME;
+            const mergeSha = process.env.MERGE_SHA;
+
+            try {
+              const existingRelease = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tagName,
+              });
+              core.info(`Release for ${tagName} already exists (#${existingRelease.data.id}). Skipping creation.`);
+              core.setOutput('release_action', 'already_exists');
+              core.setOutput('release_url', existingRelease.data.html_url || '');
+              core.setOutput('release_id', String(existingRelease.data.id));
+              return;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            const createdRelease = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tagName,
+              target_commitish: mergeSha,
+              draft: true,
+              generate_release_notes: true,
+            });
+
+            core.info(`Created draft release for ${tagName}: ${createdRelease.data.html_url}`);
+            core.setOutput('release_action', 'created');
+            core.setOutput('release_url', createdRelease.data.html_url || '');
+            core.setOutput('release_id', String(createdRelease.data.id));
+
       - name: Close Linear release PR issue
         id: linear_release_close
         env:
@@ -397,6 +441,8 @@ jobs:
             const releaseLinearUrl = `${{ steps.release_mapping.outputs.linear_url }}`;
             const releaseCloseAction = `${{ steps.linear_release_close.outputs.action }}`;
             const tagAction = `${{ steps.tag.outputs.tag_action }}`;
+            const releaseAction = `${{ steps.release.outputs.release_action }}`;
+            const releaseUrl = `${{ steps.release.outputs.release_url || steps.context.outputs.release_url }}`;
             const tagName = `${{ steps.context.outputs.tag_name }}`;
             const tagUrl = `${{ steps.context.outputs.tag_url }}`;
 
@@ -409,6 +455,8 @@ jobs:
               `- Tag: ${tagName}`,
               `- Tag URL: ${tagUrl}`,
               `- Tag action: ${tagAction}`,
+              `- Draft release URL: ${releaseUrl}`,
+              `- Draft release action: ${releaseAction}`,
               `- Linear tag action: ${linearAction}`,
               `- Linear tag ticket: ${linearIdentifier}`,
               `- Linear tag URL: ${linearUrl}`,


### PR DESCRIPTION
### Motivation
- Ensure that a draft GitHub Release object is created for generated `v*` tags on merged `development -> master` release PRs.  
- Provide clear, idempotent workflow behavior so re-runs do not duplicate releases.  
- Surface release metadata in the PR status comment so run output clearly reports actions taken.

### Description
- Emit `release_url` from the release context so downstream steps can reference a consistent release link.  
- Add a new `Create draft GitHub release if missing` step using `actions/github-script` that first calls `repos.getReleaseByTag` and only calls `repos.createRelease` with `draft: true` and `generate_release_notes: true` when the tag has no existing release.  
- Expose `release_action`, `release_url`, and `release_id` outputs for downstream reporting and idempotency checks.  
- Extend the PR status comment payload to include `Draft release URL` and `Draft release action` while preserving the existing Linear ticket closure flow.

### Testing
- Ran YAML validation with Ruby using `YAML.load_file('.github/workflows/release-merge-create-tag.yml')`, which succeeded.  
- Performed a network probe with `curl` to the GitHub Releases docs which returned `403` in this environment, so live GitHub API calls were not validated here.  
- No automated unit tests were applicable to this workflow change beyond the above validation steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe4a1bc08832a96160f496f6917e0)