### PR TITLE
[CRIS-118] Automate draft GitHub release creation for release merges

### DIFF
--- a/.github/workflows/release-merge-create-tag.yml
+++ b/.github/workflows/release-merge-create-tag.yml
@@ -105,6 +105,7 @@ jobs:
 
           TAG_NAME="$VERSION"
           TAG_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG_NAME}"
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG_NAME}"
 
           LINEAR_TITLE="[Release Tag ${TAG_NAME}] ${GITHUB_REPOSITORY}"
           LINEAR_DESCRIPTION="$(printf '%s\n' \
@@ -125,6 +126,7 @@ jobs:
             echo "pr_number=${PR_NUMBER}"
             echo "tag_name=${TAG_NAME}"
             echo "tag_url=${TAG_URL}"
+            echo "release_url=${RELEASE_URL}"
             echo "merge_sha=${MERGE_SHA}"
             echo "linear_title=${LINEAR_TITLE}"
             echo "linear_description<<${DELIMITER}"
@@ -341,6 +343,48 @@ jobs:
           source scripts/tools/linear_sync_lib.sh
           linear_emit_summary "$LINEAR_IDENTIFIER" "$ACTION"
 
+      - name: Create draft GitHub release if missing
+        id: release
+        uses: actions/github-script@v7
+        env:
+          TAG_NAME: ${{ steps.context.outputs.tag_name }}
+          MERGE_SHA: ${{ steps.context.outputs.merge_sha }}
+        with:
+          script: |
+            const tagName = process.env.TAG_NAME;
+            const mergeSha = process.env.MERGE_SHA;
+
+            try {
+              const existingRelease = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tagName,
+              });
+              core.info(`Release for ${tagName} already exists (#${existingRelease.data.id}). Skipping creation.`);
+              core.setOutput('release_action', 'already_exists');
+              core.setOutput('release_url', existingRelease.data.html_url || '');
+              core.setOutput('release_id', String(existingRelease.data.id));
+              return;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            const createdRelease = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tagName,
+              target_commitish: mergeSha,
+              draft: true,
+              generate_release_notes: true,
+            });
+
+            core.info(`Created draft release for ${tagName}: ${createdRelease.data.html_url}`);
+            core.setOutput('release_action', 'created');
+            core.setOutput('release_url', createdRelease.data.html_url || '');
+            core.setOutput('release_id', String(createdRelease.data.id));
+
       - name: Close Linear release PR issue
         id: linear_release_close
         env:
@@ -395,6 +439,8 @@ jobs:
             const releaseLinearUrl = `${{ steps.release_mapping.outputs.linear_url }}`;
             const releaseCloseAction = `${{ steps.linear_release_close.outputs.action }}`;
             const tagAction = `${{ steps.tag.outputs.tag_action }}`;
+            const releaseAction = `${{ steps.release.outputs.release_action }}`;
+            const releaseUrl = `${{ steps.release.outputs.release_url || steps.context.outputs.release_url }}`;
             const tagName = `${{ steps.context.outputs.tag_name }}`;
             const tagUrl = `${{ steps.context.outputs.tag_url }}`;
 
@@ -407,6 +453,8 @@ jobs:
               `- Tag: ${tagName}`,
               `- Tag URL: ${tagUrl}`,
               `- Tag action: ${tagAction}`,
+              `- Draft release URL: ${releaseUrl}`,
+              `- Draft release action: ${releaseAction}`,
               `- Linear tag action: ${linearAction}`,
               `- Linear tag ticket: ${linearIdentifier}`,
               `- Linear tag URL: ${linearUrl}`,


### PR DESCRIPTION
## Summary
- add draft GitHub Release creation for release merge tags when missing
- keep idempotency by checking existing release via tag before create
- include release action/url in the PR status comment payload

## Validation
- YAML parse check for `.github/workflows/release-merge-create-tag.yml` passed

Closes CRIS-118

Supersedes #39 (opened against master).
