### PR TITLE
[CRIS-121] Harden branch remediation normalization and contract checks

### DIFF
--- a/.github/workflows/auto-create-pr-from-codex-branch.yml
+++ b/.github/workflows/auto-create-pr-from-codex-branch.yml
@@ -27,7 +27,8 @@ jobs:
             const sourceBranch = context.ref.replace('refs/heads/', '');
             const sourceSha = context.sha;
             const canonicalPattern = /^codex\/([A-Z]+-\d+)-([a-z0-9][a-z0-9._-]*)$/;
-            const legacyPattern = /^(?:feature\/)?([a-z]+-\d+)-(.+)$/i;
+            const legacyPattern = /^(?:(?:codex|feature)\/)?([a-z]+-\d+)-(.+)$/i;
+            const looseLinearPattern = /(?:^|[-_/])([a-z]+-\d+)(?:[-_/]|$)/i;
             const allowedKeysRaw = (process.env.LINEAR_ALLOWED_KEYS || 'CRIS,CE').toUpperCase();
             const allowedKeys = new Set(
               allowedKeysRaw
@@ -39,6 +40,38 @@ jobs:
               allowedKeys.add('CRIS');
               allowedKeys.add('CE');
             }
+
+            const sanitizeSlug = (value) => value
+              .toLowerCase()
+              .replace(/[^a-z0-9._-]+/g, '-')
+              .replace(/-+/g, '-')
+              .replace(/^-|-$/g, '');
+
+            const deriveFromNonCanonicalCodex = (branchName) => {
+              if (!branchName.startsWith('codex/')) {
+                return null;
+              }
+
+              const tail = branchName.slice('codex/'.length);
+              const idMatch = tail.match(looseLinearPattern);
+              if (!idMatch) {
+                return null;
+              }
+
+              const idRaw = idMatch[1];
+              const linearId = idRaw.toUpperCase();
+              const lowerTail = tail.toLowerCase();
+              const matchIndex = lowerTail.indexOf(idRaw.toLowerCase());
+              const suffix = tail.slice(matchIndex + idRaw.length).replace(/^[-_/]+/, '');
+              const prefix = tail.slice(0, matchIndex).replace(/[-_/]+$/, '');
+              const slug = sanitizeSlug(suffix || prefix || `${linearId.toLowerCase()}-work`);
+
+              if (!slug || !/^[a-z0-9][a-z0-9._-]*$/.test(slug)) {
+                return null;
+              }
+
+              return { linearId, slug };
+            };
 
             try {
               const sourceRef = await github.rest.git.getRef({
@@ -70,17 +103,19 @@ jobs:
               slug = canonicalMatch[2];
             } else {
               const legacyMatch = sourceBranch.match(legacyPattern);
-              if (!legacyMatch) {
+              const looseCodexMatch = deriveFromNonCanonicalCodex(sourceBranch);
+              if (!legacyMatch && !looseCodexMatch) {
                 core.notice(`Skipping non-conforming branch: ${sourceBranch}`);
                 return;
               }
 
-              linearId = legacyMatch[1].toUpperCase();
-              slug = legacyMatch[2]
-                .toLowerCase()
-                .replace(/[^a-z0-9._-]+/g, '-')
-                .replace(/-+/g, '-')
-                .replace(/^-|-$/g, '');
+              if (legacyMatch) {
+                linearId = legacyMatch[1].toUpperCase();
+                slug = sanitizeSlug(legacyMatch[2]);
+              } else if (looseCodexMatch) {
+                linearId = looseCodexMatch.linearId;
+                slug = looseCodexMatch.slug;
+              }
 
               if (!slug || !/^[a-z0-9][a-z0-9._-]*$/.test(slug)) {
                 core.notice(`Could not normalize branch slug from: ${sourceBranch}`);

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -78,9 +78,11 @@ jobs:
         run: |
           bash -n "scripts/tools/analyze_capture_metrics.sh"
           bash -n "scripts/tools/linear_sync_lib.sh"
+          bash -n "scripts/tools/test_auto_create_pr_branch_policy_contract.sh"
           bash -n "scripts/tools/test_require_linked_issue_contract.sh"
-          shellcheck scripts/tools/linear_sync_lib.sh scripts/tools/test_require_linked_issue_contract.sh
+          shellcheck scripts/tools/linear_sync_lib.sh scripts/tools/test_auto_create_pr_branch_policy_contract.sh scripts/tools/test_require_linked_issue_contract.sh
 
       - name: PR payload smoke tests
         run: |
+          bash scripts/tools/test_auto_create_pr_branch_policy_contract.sh
           bash scripts/tools/test_require_linked_issue_contract.sh

--- a/docs/setup/branch-remediation-runbook.md
+++ b/docs/setup/branch-remediation-runbook.md
@@ -1,0 +1,37 @@
+# Branch Remediation Runbook (Strict Linked-Issue Enforcement)
+
+Use this runbook when a PR fails `require-linked-issue` because branch naming does not follow `codex/<KEY>-<number>-<slug>`.
+
+## Core rule
+
+- Do not rename or delete an open PR head branch in place.
+- GitHub PR head refs are not safely mutable during remediation and can auto-close or destabilize the PR.
+
+## Standard remediation workflow
+
+1. Identify canonical branch name from the linked issue.
+2. Create or update the canonical branch to the same commit SHA as the legacy/non-compliant source branch.
+3. Open a replacement PR from the canonical branch into `development`.
+4. Copy useful context from the superseded PR (description, checklist, references).
+5. Close the superseded PR with a note that links the replacement PR.
+6. Continue review and merge on the canonical PR only.
+
+## Automation-first path
+
+If `.github/workflows/auto-create-pr-from-codex-branch.yml` is active:
+
+- Pushes from compatible legacy branch forms (`<key>-<number>-<slug>`, `feature/<key>-<number>-<slug>`, and non-canonical `codex/*` names that include a valid issue ID) are normalized into canonical `codex/<KEY>-<number>-<slug>` branches before PR creation.
+- If an open PR already exists for the canonical branch, automation does not create duplicates.
+
+## Verification checklist
+
+- Canonical branch exists and matches expected issue ID/slug.
+- Replacement PR title matches `[<KEY>-<number>] <short title>`.
+- Optional magic words (if used) match the same ID.
+- `require-linked-issue` passes.
+- Superseded PR is clearly marked and closed.
+
+## Regression case reference
+
+- Incident pattern: `codex/linear-mention-cris-16-research-strict-userscript-blocker`
+- Expected normalization target: `codex/CRIS-16-research-strict-userscript-blocker`

--- a/docs/setup/linear-github-codex-automation.md
+++ b/docs/setup/linear-github-codex-automation.md
@@ -180,6 +180,7 @@ curl -X POST \
 ## 7) Runbook and observability
 
 - Runbook: [`docs/setup/linear-sync-runbook.md`](./linear-sync-runbook.md)
+- Branch remediation runbook: [`docs/setup/branch-remediation-runbook.md`](./branch-remediation-runbook.md)
 - Each Linear sync workflow emits structured status lines in this format:
   - `linear_sync linear_id=<identifier> ce_id=<identifier> status=<updated|already_done|not_found|failed> reason=<optional>`
 - Use this output for audit, alerting, and manual replay triage.

--- a/scripts/tools/test_auto_create_pr_branch_policy_contract.sh
+++ b/scripts/tools/test_auto_create_pr_branch_policy_contract.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+normalize_branch() {
+  local source_branch="$1"
+  local allowed_keys_csv="${2:-CRIS,CE}"
+
+  node - "$source_branch" "$allowed_keys_csv" <<'NODE'
+const sourceBranch = process.argv[2];
+const allowedKeysRaw = process.argv[3] || 'CRIS,CE';
+
+const canonicalPattern = /^codex\/([A-Z]+-\d+)-([a-z0-9][a-z0-9._-]*)$/;
+const legacyPattern = /^(?:(?:codex|feature)\/)?([a-z]+-\d+)-(.+)$/i;
+const looseLinearPattern = /(?:^|[-_/])([a-z]+-\d+)(?:[-_/]|$)/i;
+
+const allowedKeys = new Set(
+  allowedKeysRaw
+    .toUpperCase()
+    .split(',')
+    .map((key) => key.trim())
+    .filter(Boolean),
+);
+
+if (allowedKeys.size === 0) {
+  allowedKeys.add('CRIS');
+  allowedKeys.add('CE');
+}
+
+function sanitizeSlug(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function deriveFromNonCanonicalCodex(branchName) {
+  if (!branchName.startsWith('codex/')) {
+    return null;
+  }
+
+  const tail = branchName.slice('codex/'.length);
+  const idMatch = tail.match(looseLinearPattern);
+  if (!idMatch) {
+    return null;
+  }
+
+  const idRaw = idMatch[1];
+  const linearId = idRaw.toUpperCase();
+  const lowerTail = tail.toLowerCase();
+  const matchIndex = lowerTail.indexOf(idRaw.toLowerCase());
+  const suffix = tail.slice(matchIndex + idRaw.length).replace(/^[-_/]+/, '');
+  const prefix = tail.slice(0, matchIndex).replace(/[-_/]+$/, '');
+  const slug = sanitizeSlug(suffix || prefix || `${linearId.toLowerCase()}-work`);
+
+  if (!slug || !/^[a-z0-9][a-z0-9._-]*$/.test(slug)) {
+    return null;
+  }
+
+  return { linearId, slug };
+}
+
+let branch = sourceBranch;
+let linearId = '';
+let slug = '';
+let normalizedFrom = '';
+
+const canonicalMatch = sourceBranch.match(canonicalPattern);
+if (canonicalMatch) {
+  linearId = canonicalMatch[1];
+  slug = canonicalMatch[2];
+} else {
+  const legacyMatch = sourceBranch.match(legacyPattern);
+  const looseCodexMatch = deriveFromNonCanonicalCodex(sourceBranch);
+
+  if (legacyMatch) {
+    linearId = legacyMatch[1].toUpperCase();
+    slug = sanitizeSlug(legacyMatch[2]);
+  } else if (looseCodexMatch) {
+    linearId = looseCodexMatch.linearId;
+    slug = looseCodexMatch.slug;
+  } else {
+    console.log('SKIP_NON_CONFORMING');
+    process.exit(0);
+  }
+
+  if (!slug || !/^[a-z0-9][a-z0-9._-]*$/.test(slug)) {
+    console.log('SKIP_BAD_SLUG');
+    process.exit(0);
+  }
+
+  const legacyLinearKey = linearId.split('-')[0];
+  if (!allowedKeys.has(legacyLinearKey)) {
+    console.log(`SKIP_DISALLOWED_KEY:${legacyLinearKey}`);
+    process.exit(0);
+  }
+
+  branch = `codex/${linearId}-${slug}`;
+  normalizedFrom = sourceBranch;
+}
+
+const linearKey = linearId.split('-')[0];
+if (!allowedKeys.has(linearKey)) {
+  console.log(`SKIP_DISALLOWED_KEY:${linearKey}`);
+  process.exit(0);
+}
+
+console.log(JSON.stringify({ branch, linearId, slug, normalizedFrom }));
+NODE
+}
+
+assert_normalized() {
+  local source_branch="$1"
+  local expected_branch="$2"
+  local expected_linear_id="$3"
+  local expected_slug="$4"
+  local expected_from="$5"
+  local allowed_keys="${6:-CRIS,CE}"
+
+  local out
+  out="$(normalize_branch "$source_branch" "$allowed_keys")"
+  local expected
+  expected="{\"branch\":\"$expected_branch\",\"linearId\":\"$expected_linear_id\",\"slug\":\"$expected_slug\",\"normalizedFrom\":\"$expected_from\"}"
+
+  if [ "$out" != "$expected" ]; then
+    echo "Normalization assertion failed for: $source_branch"
+    echo "Expected: $expected"
+    echo "Actual:   $out"
+    exit 1
+  fi
+}
+
+assert_skip() {
+  local source_branch="$1"
+  local expected_prefix="$2"
+  local allowed_keys="${3:-CRIS,CE}"
+
+  local out
+  out="$(normalize_branch "$source_branch" "$allowed_keys")"
+  if [[ "$out" != "$expected_prefix"* ]]; then
+    echo "Skip assertion failed for: $source_branch"
+    echo "Expected prefix: $expected_prefix"
+    echo "Actual:          $out"
+    exit 1
+  fi
+}
+
+# Canonical branch is preserved.
+assert_normalized \
+  'codex/CRIS-121-fix-branch-policy' \
+  'codex/CRIS-121-fix-branch-policy' \
+  'CRIS-121' \
+  'fix-branch-policy' \
+  ''
+
+# Legacy branch is normalized to canonical codex/ form.
+assert_normalized \
+  'cris-121-Finalize Branch remediation!!!' \
+  'codex/CRIS-121-finalize-branch-remediation' \
+  'CRIS-121' \
+  'finalize-branch-remediation' \
+  'cris-121-Finalize Branch remediation!!!'
+
+# Non-canonical codex/ branch with leading issue token is normalized.
+assert_normalized \
+  'codex/cris-405-Title.With MIXED Case' \
+  'codex/CRIS-405-title.with-mixed-case' \
+  'CRIS-405' \
+  'title.with-mixed-case' \
+  'codex/cris-405-Title.With MIXED Case'
+
+# Non-canonical codex/ branch with embedded issue token is normalized.
+assert_normalized \
+  'codex/linear-mention-cris-16-research-strict-userscript-blocker' \
+  'codex/CRIS-16-research-strict-userscript-blocker' \
+  'CRIS-16' \
+  'research-strict-userscript-blocker' \
+  'codex/linear-mention-cris-16-research-strict-userscript-blocker'
+
+# feature/ legacy prefix is normalized.
+assert_normalized \
+  'feature/ce-404-Fix.Mixed_slug value' \
+  'codex/CE-404-fix.mixed_slug-value' \
+  'CE-404' \
+  'fix.mixed_slug-value' \
+  'feature/ce-404-Fix.Mixed_slug value'
+
+# Unknown branch shape is ignored.
+assert_skip 'hotfix/no-linear-id' 'SKIP_NON_CONFORMING'
+
+# Disallowed keys are ignored.
+assert_skip 'feature/abc-77-test-slug' 'SKIP_DISALLOWED_KEY:ABC'
+assert_skip 'codex/CE-500-allowed-only-under-transition' 'SKIP_DISALLOWED_KEY:CE' 'CRIS'
+
+echo 'auto-create-pr branch policy contract smoke tests passed'


### PR DESCRIPTION
## Summary
- harden auto-create PR normalization to handle non-canonical codex branches containing valid issue ids
- add branch remediation runbook for safe replacement-PR workflow
- add contract smoke tests for auto-create branch policy and wire them into validate CI

## Validation
- bash scripts/tools/test_auto_create_pr_branch_policy_contract.sh
- bash scripts/tools/test_require_linked_issue_contract.sh

Closes CRIS-121