### PR TITLE
[CRIS-18] Update release prep plan for post-v8.2 cut

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ For v9 strict-blocker release planning, see:
 
 - `docs/changelog/v9-roadmap.md`
 
+For the next release after `v8.2` (`CRIS-18`), see:
+
+- `docs/setup/linear-v9-release-plan.md`
+
 ## Project Context Images
 
 ![M-Game Setup](evidence/screenshots/M%20Game%20RGB.png)

--- a/docs/setup/linear-v9-release-plan.md
+++ b/docs/setup/linear-v9-release-plan.md
@@ -1,89 +1,86 @@
-# Linear Configuration: v9 Strict WebRTC Blocker Release
+# Linear Configuration: Post-v8.2 Release Prep (CRIS-18)
 
-Team:
+This document tracks the next production release after tag `v8.2`.
 
-- `CE`
+## Release Tracker
 
-Labels:
-
-- `webrtc`
-- `tampermonkey`
-- `release-v9`
-- `privacy`
-
-Target window:
-
-- Start: February 24, 2026
-- End: March 10, 2026
-
-## Milestone / release bucket
-
-- Issue key: `CE-NEW-1` (placeholder)
-- Title: `[CE-NEW-1] v9.0 milestone: minimum WebRTC disable (selected domains)`
+- Issue key: `CRIS-18`
+- Title: `Release prep: next version after v8.2 (v10/v11 media hardening + CRIS workflow governance)`
 - Scope:
-  - Release tracking
-  - Child issue linkage
-  - Go/no-go checklist
-  - Release notes draft
+  - Confirm release-ready state of the `development` baseline
+  - Verify whether `CRIS-123` is included in this release cut
+  - Prepare `development -> main` release PR content
+  - Track post-merge tag + draft-release automation
 
-## Work tickets
+## Included Work (Current Baseline)
 
-### CE-NEW-2
+### Workflow and governance hardening
 
-- Title: `[CE-NEW-2] Implement strict WebRTC blocker userscript for Atlas + X`
-- Linear issue: `<to be created>`
-- Priority: `High`
-- Scope:
-  - Add standalone userscript artifact
-  - Strict-only behavior
-  - Selected domain matches (`chatgpt.com`, `x.com`, `twitter.com`)
-- Acceptance:
-  - On target domains, blocked APIs are not usable
-  - Script loads at `document-start`
-  - No changes to `scripts/current/M-Game Clean Audio.user.js`
+- `CRIS-120` — branch/PR governance migration to CRIS-first
+- `CRIS-121` — branch remediation hardening and contract checks
 
-### CE-NEW-3
+### WebRTC script evolution
 
-- Title: `[CE-NEW-3] Add validation matrix for strict blocking behavior`
-- Linear issue: `<to be created>`
-- Priority: `High`
-- Scope:
-  - Create reproducible validation matrix
-  - Include one non-target domain control test
-- Acceptance:
-  - Matrix completed
-  - Regressions documented
+- `CRIS-122` — v10 minimal music-first constraints hardener for X/Atlas
+- `CRIS-123` — v11 DEBUG diagnostics for `getUserMedia` / `applyConstraints` hardening
 
-### CE-NEW-4
+## Release Readiness Checklist
 
-- Title: `[CE-NEW-4] Documentation for install, scope, and known breakage`
-- Linear issue: `<to be created>`
-- Priority: `Medium`
-- Scope:
-  - Install flow
-  - Limitations and rollback
-  - Known breakage warning
-- Acceptance:
-  - Clear docs published for install/use/rollback
+- [x] CRIS workflow hardening completed (`CRIS-120`, `CRIS-121`)
+- [x] v10 minimal hardener completed (`CRIS-122`)
+- [ ] Confirm `CRIS-123` merged into `development` (or explicitly defer)
+- [ ] Open/merge release PR `development -> main`
+- [ ] Validate tag + draft GitHub Release automation
+- [ ] Finalize release notes (media hardening + debug behavior + workflow updates)
 
-### CE-NEW-5
+## Decision Gate
 
-- Title: `[CE-NEW-5] Research note: userscript strict block vs WebRTC Control extension`
-- Linear issue: `<to be created>`
-- Priority: `Medium`
-- Scope:
-  - Evidence-backed comparison
-  - Recommendation boundaries
-- Acceptance:
-  - Final note published in `docs/analysis/`
+- If `CRIS-123` is merged in time, include v11 diagnostics in this release.
+- If `CRIS-123` is not merged in time, release from current `development` baseline and defer v11.
 
-## Workflow notes
+## Workflow Contract
 
-- Branch format: `codex/CE-<number>-<slug>`
-- PR title format: `[CE-<number>] <short title>`
-- Optional magic words must use the same `CE-<number>`
-- Normal work targets `development`
+- Branch format (normal work): `codex/CRIS-<number>-<slug>`
+- PR title format (normal work): `[CRIS-<number>] <short title>`
+- Release flow exemption: `development -> main`
+- Required checks: `validate`, `require-linked-issue`, `codex-review`
 
-## Status
+## Release PR Body Template
 
-Use private Linear workspace references (not committed in repository files) to map these placeholders to real issue IDs and URLs.
+```md
+## Release Summary
+Promote `development` to `main` for the next release after `v8.2`.
+
+Closes CRIS-18.
+
+## Included Work
+- [x] CRIS-120: CRIS-first branch/PR governance migration
+- [x] CRIS-121: branch remediation hardening
+- [x] CRIS-122: v10 minimal music-first WebRTC constraints hardener
+- [ ] CRIS-123: v11 DEBUG diagnostics (check only if merged in `development` before release merge)
+
+## Pre-Merge Checklist
+- [ ] `validate` green
+- [ ] `require-linked-issue` green
+- [ ] `codex-review` green
+- [ ] Final release notes reviewed
+- [ ] Decision recorded: include/exclude CRIS-123 in this cut
+
+## Post-Merge Verification
+- [ ] Tag auto-created from release workflow
+- [ ] Draft GitHub Release auto-created
+- [ ] Linear release tracking updated
+```
+
+## Release Gate Comment Template
+
+```md
+Release gate check for `development -> main`:
+
+- CI required checks: ✅/❌
+- CRIS-123 included in this release: ✅/❌
+- Tag + draft release automation expected: ✅
+- Decision: merge now / hold for CRIS-123
+
+If merged now, this closes CRIS-18 and starts post-merge release verification.
+```


### PR DESCRIPTION
### Motivation
- Replace an outdated CE/v9 placeholder release plan with a focused tracker for the next production cut after tag `v8.2` (CRIS-18). 
- Surface the current included work (`CRIS-120`, `CRIS-121`, `CRIS-122`) and provide a clear decision gate for whether `CRIS-123` is included. 
- Provide reusable, copy-pastable templates and a checklist to make the `development -> main` release PR and gate comments consistent. 

### Description
- Rewrote `docs/setup/linear-v9-release-plan.md` into a CRIS-18-focused release-prep document that includes a release tracker, included-work summary, decision gate, workflow contract, and a `development -> main` PR body template. 
- Updated `README.md` to add a pointer to the refreshed release-prep document for the next release after `v8.2`. 
- Added a release gate comment template and a pre-merge/post-merge checklist to the docs to standardize the release cut process. 
- Changes were committed on branch `codex/CRIS-18-release-prep-post-v82`. 

### Testing
- Ran `rg -n "CRIS-18|CRIS-123|development -> main" docs/setup/linear-v9-release-plan.md README.md` to verify the new references and templates are present, and the command returned matching lines indicating success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3cbc12c58832a99a283b1ce0857f0)